### PR TITLE
[issue/#37] documentation how to export realms including users

### DIFF
--- a/export.single-realm-files.docker-compose.yml
+++ b/export.single-realm-files.docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.1'
+services:
+  keycloak:
+    image: jboss/keycloak:6.0.1
+    environment:
+      KEYCLOAK_PASSWORD: admin123
+      KEYCLOAK_USER: admin
+    volumes:
+      - ./tmp:/tmp
+    ports:
+    - "8080:8080"
+    - "8787:8787"
+    command:
+    - "-b"
+    - "0.0.0.0"
+    - "--debug"
+    - "-Dkeycloak.migration.action=export"
+    - "-Dkeycloak.migration.provider=dir"
+    - "-Dkeycloak.migration.dir=/tmp"
+    - "-Dkeycloak.migration.usersExportStrategy=REALM_FILE"


### PR DESCRIPTION
when using export.docker-compose.yml it seperates the realms user and role data into an additional export.json file.
add new docker-compose file which prevents this behaviour and only exports one file per realm.