### PR TITLE
Support yaml as import format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added Helm Chart
+- Support yaml as configuration import format. (`--import.file-type=yaml`)
 
 ### Changed
+
 - Set user to 1001 in Dockerfile
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # keycloak-config-cli
 
-keycloak-config-cli is a Keycloak utility to ensure the desired configuration state for a realm based on a JSON file. The format of the JSON file based on the export realm format. Store and handle the configuration files inside git just like normal code. A Keycloak restart isn't required to apply the configuration.
+keycloak-config-cli is a Keycloak utility to ensure the desired configuration state for a realm based on a JSON/YAML file. The format of the JSON/YAML file based on the export realm format. Store and handle the configuration files inside git just like normal code. A Keycloak restart isn't required to apply the configuration.
 
 ## Config files
 
@@ -92,21 +92,22 @@ add it as dependency to your chart deployment.
 
 Checkout helm docs about [chart dependencies](https://helm.sh/docs/topics/charts/#chart-dependencies)!
 
-#### Environment Variables
+#### CLI option / Environment Variables
 
-| Variable             | Description                                                                  | Default     |
-| -------------------- | ---------------------------------------------------------------------------- | ----------- |
-| WAIT_TIME_IN_SECONDS | Timeout in seconds for waiting keycloak until reachable                      | `120`       |
-| KEYCLOAK_URL         | Keycloak Url without `/auth`                                                 | -           |
-| KEYCLOAK_USER        | login user name                                                              | `admin`     |
-| KEYCLOAK_PASSWORD    | login user name                                                              | -           |
-| KEYCLOAK_CLIENTID    | login clientId                                                               | `admin-cli` |
-| KEYCLOAK_LOGINREALM  | login realm                                                                  | `master`    |
-| KEYCLOAK_SSLVERIFY   | Verify ssl connection to keycloak                                            | `true`      |
-| IMPORT_PATH          | Location of config files                                                     | `/config`   |
-| IMPORT_FORCE         | Enable force import of realm config                                          | `false`     |
-| IMPORT_CACHEKEY      | Cache key for importing config.                                              | `default`   |
-| IMPORT_STATE         | Enable state management. Purge only resources managed by kecloak-config-cli. | `true`      |
+|  CLI option            | Variable             | Description                                                                  | Default     |
+| ---------------------- | -------------------- | ---------------------------------------------------------------------------- | ----------- |
+| -                      | WAIT_TIME_IN_SECONDS | Timeout in seconds for waiting keycloak until reachable. Only inside docker. | `120`       |
+| --keycloak.url         | KEYCLOAK_URL         | Keycloak Url without `/auth`                                                 | -           |
+| --keycloak.user        | KEYCLOAK_USER        | login user name                                                              | `admin`     |
+| --keycloak.password    | KEYCLOAK_PASSWORD    | login user name                                                              | -           |
+| --keycloak.client-id   | KEYCLOAK_CLIENTID    | login clientId                                                               | `admin-cli` |
+| --keycloak.login-realm | KEYCLOAK_LOGINREALM  | login realm                                                                  | `master`    |
+| --keycloak.ssl-verify  | KEYCLOAK_SSLVERIFY   | Verify ssl connection to keycloak                                            | `true`      |
+| --import.path          | IMPORT_PATH          | Location of config files                                                     | `/config`   |
+| --import.force         | IMPORT_FORCE         | Enable force import of realm config                                          | `false`     |
+| --import.cache-key     | IMPORT_CACHEKEY      | Cache key for importing config.                                              | `default`   |
+| --import.state         | IMPORT_STATE         | Enable state management. Purge only resources managed by kecloak-config-cli. | `true`      |
+| --import.file-type     | IMPORT_FILETYPE      | Format of the configuration import file. Allowed values: JSON/YAML           | `json`      |
 
 ### Experimental native build
 
@@ -120,7 +121,6 @@ Benefits:
 
 Limitations:
 
-- YAML based properties not supported. Use environment variable, command line parameters or old style properties.
 - Some dynamic jvm features needs to be define manually in graalvm. The [list](src/main/resources/META-INF/native-image/10.0.2/reflect-config.json) isn't complete which can be result in an unexpected behavior.
 
 It might be not production ready yet.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -16,7 +16,7 @@
 | Remove role from user                      | 1.0.0 | Remove realm-level or client-level roles from user while updating realm                                  |
 | Add authentication flows and executions    | 1.0.0 | Add authentication flows and executions while creating or updating realms                                |
 | Update authentication flows and executions | 1.0.0 | Update authentication flow properties and executions while updating realms                               |
-| Remove authentication flows and executions | 2.0.0 | Remove existing authentication flow properties and executions while updating realms                               |
+| Remove authentication flows and executions | 2.0.0 | Remove existing authentication flow properties and executions while updating realms                      |
 | Add components                             | 1.0.0 | Add components while creating or updating realms                                                         |
 | Update components                          | 1.0.0 | Update components properties while updating realms                                                       |
 | Remove components                          | 2.0.0 | Remove existing sub-components while creating or updating realms                                         |

--- a/docs/MANAGED.md
+++ b/docs/MANAGED.md
@@ -48,6 +48,6 @@ If `import.state` is set to `false`, keycloak-config-cli will purge all existing
 
 Following entities does have saved state:
 
-* Required Actions
-* Clients
-* Components
+- Required Actions
+- Clients
+- Components

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
             <artifactId>commons-codec</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+
         <!-- TEST -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -388,18 +393,18 @@
 						<version>20.1.0</version>
 						<configuration>
                             <imageName>keycloak-config-cli-native</imageName>
-							<buildArgs>--no-fallback --no-server
-								--enable-http --enable-https
-								--initialize-at-run-time=org.hibernate.validator.internal.engine.messageinterpolation.ElTermResolver
-								-H:+ReportExceptionStackTraces
-								-Dspring.native.dump-config=feature-reflect-config.json
-								-Dspring.native.verbose=false
-								-Dspring.native.remove-unused-autoconfig=true
-								-Dspring.native.remove-yaml-support=true
-								-Dspring.native.remove-jmx-support=true
-								-Dspring.native.remove-xml-support=false
-								-Dspring.native.remove-spel-support=true
-							</buildArgs>
+                            <buildArgs>--no-fallback --no-server
+                                --enable-http --enable-https
+                                --initialize-at-run-time=org.hibernate.validator.internal.engine.messageinterpolation.ElTermResolver
+                                -H:+ReportExceptionStackTraces
+                                -Dspring.native.dump-config=feature-reflect-config.json
+                                -Dspring.native.verbose=false
+                                -Dspring.native.remove-unused-autoconfig=true
+                                -Dspring.native.remove-jmx-support=true
+                                -Dspring.native.remove-spel-support=true
+                                -Dspring.native.remove-yaml-support=false
+                                -Dspring.native.remove-xml-support=false
+                            </buildArgs>
 						</configuration>
 						<executions>
 							<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <keycloak.version>10.0.2</keycloak.version>
+        <jackson.version>2.11.0</jackson.version>
         <testcontainers.version>1.14.3</testcontainers.version>
 
         <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
@@ -85,15 +86,23 @@
 
 	<!-- Intellij friendly POM -->
 	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.keycloak</groupId>
-				<artifactId>keycloak-parent</artifactId>
-				<version>${keycloak.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-parent</artifactId>
+                <version>${keycloak.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
 	</dependencyManagement>
 
 	<dependencies>

--- a/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
+++ b/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
@@ -46,13 +46,17 @@ public class ImportConfigProperties {
     @NotNull
     private final boolean state;
 
+    @NotNull
+    private final ImportFileType fileType;
+
     private final ImportManagedProperties managed;
 
-    public ImportConfigProperties(String path, boolean force, String cacheKey, boolean state, ImportManagedProperties managed) {
+    public ImportConfigProperties(String path, boolean force, String cacheKey, boolean state, ImportFileType fileType, ImportManagedProperties managed) {
         this.path = path;
         this.force = force;
         this.cacheKey = cacheKey;
         this.state = state;
+        this.fileType = fileType;
         this.managed = managed;
     }
 
@@ -74,6 +78,10 @@ public class ImportConfigProperties {
 
     public boolean isState() {
         return state;
+    }
+
+    public ImportFileType getFileType() {
+        return fileType;
     }
 
     public static class ImportManagedProperties {
@@ -144,5 +152,10 @@ public class ImportConfigProperties {
             FULL,
             NO_DELETE
         }
+    }
+
+    public enum ImportFileType {
+        JSON,
+        YAML
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,7 @@ keycloak.ssl-verify=true
 import.cache-key=default
 import.force=false
 import.state=true
+import.file-type=json
 import.managed.authentication-flow=full
 import.managed.group=full
 import.managed.required-action=full

--- a/src/test/java/de/adorsys/keycloak/config/ImportSimpleRealmYamlIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/ImportSimpleRealmYamlIT.java
@@ -1,0 +1,57 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2020 adorsys GmbH & Co. KG @ https://adorsys.de
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+
+@TestPropertySource(properties = {
+        "import.file-type=yaml",
+})
+class ImportSimpleRealmYamlIT extends AbstractImportTest {
+    private static final String REALM_NAME = "simpleYaml";
+
+    ImportSimpleRealmYamlIT() {
+        this.resourcePath = "import-files/simple-realm-yaml";
+    }
+
+    @Test
+    @Order(0)
+    void shouldCreateSimpleRealm() {
+        doImport("0_create_simple-realm.yaml");
+
+        RealmRepresentation createdRealm = keycloakProvider.get().realm(REALM_NAME).toRepresentation();
+
+        assertThat(createdRealm.getRealm(), is(REALM_NAME));
+        assertThat(createdRealm.isEnabled(), is(true));
+        assertThat(createdRealm.getLoginTheme(), is(nullValue()));
+        assertThat(
+                createdRealm.getAttributes().get("de.adorsys.keycloak.config.import-checksum-default"),
+                is("de0fd72cce66f641973bde5a13b648582eb2a0718d2cdcd1075bb2ec464d3eb6")
+        );
+    }
+}

--- a/src/test/java/de/adorsys/keycloak/config/properties/ImportConfigPropertiesTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/properties/ImportConfigPropertiesTest.java
@@ -41,6 +41,7 @@ import static org.hamcrest.core.Is.is;
         "import.force=true",
         "import.path=other",
         "import.state=false",
+        "import.file-type=yaml",
         "import.managed.authentication-flow=no-delete",
         "import.managed.group=no-delete",
         "import.managed.required-action=no-delete",
@@ -60,6 +61,7 @@ class ImportConfigPropertiesTest {
         assertThat(properties.isForce(), is(true));
         assertThat(properties.getCacheKey(), is("custom"));
         assertThat(properties.isState(), is(false));
+        assertThat(properties.getFileType(), is(ImportConfigProperties.ImportFileType.YAML));
         assertThat(properties.getManaged().getAuthenticationFlow(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getGroup(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getRequiredAction(), is(ImportManagedPropertiesValues.NO_DELETE));

--- a/src/test/resources/import-files/simple-realm-yaml/0_create_simple-realm.yaml
+++ b/src/test/resources/import-files/simple-realm-yaml/0_create_simple-realm.yaml
@@ -1,0 +1,2 @@
+enabled: true
+realm: simpleYaml


### PR DESCRIPTION
Added a switch `--import.file-type=yaml` to allow yaml format as configuration import.