### PR TITLE
Improve identity provider and mapper handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,6 @@ indent_style = space
 [*.{json, yaml, xml}]
 indent_size = 2
 
-[*.xml]
+[*.{xml, java}]
 indent_size = 4
+continuation_indent_size = 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Create, Update, Delete IdentityProviderMappers
+- Support for only updating changed IdentityProviders
+- Support for managed IdentityProviders
+
 ### Changed
 
 ### Fixed

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -40,7 +40,12 @@
 | Add required-actions                               | 1.0.0 | Add required-actions while creating or updating realms                                                   |
 | Update required-actions                            | 1.0.0 | Update properties of existing required-actions while updating realms                                     |
 | Remove required-actions                            | 2.0.0 | Remove existing required-actions while updating realms                                                   |
-| Update identity providers                          | 1.2.0 | Update properties of existing identity providers while updating realms                                   |
+| Add identity providers                             | 1.2.0 | Add identity providers while creating or updating realms                                                 |
+| Update identity providers                          | 1.2.0 | Update identity providers while updating realms (improved with 2.0.0)                                    |
+| Remove identity providers                          | 2.0.0 | Remove identity providers while updating realms                                                          |
+| Add identity provider mappers                      | 2.0.0 | Add identityProviderMappers while updating realms                                                        |
+| Update identity provider mappers                   | 2.0.0 | Update identityProviderMappers while updating realms                                                     |
+| Remove identity provider mappers                   | 2.0.0 | Remove identityProviderMappers while updating realms                                                     |
 | Add clientScopes                                   | 2.0.0 | Add clientScopes (inclusive protocolMappers) while creating or updating realms                           |
 | Update clientScopes                                | 2.0.0 | Update existing (inclusive protocolMappers) clientScopes while creating or updating realms               |
 | Remove clientScopes                                | 2.0.0 | Remove existing clientScopes while creating or updating realms                                           |

--- a/docs/MANAGED.md
+++ b/docs/MANAGED.md
@@ -24,15 +24,17 @@ For example if you define `groups` but set an empty array, keycloak will delete 
 
 ## Supported full managed entities
 
-| Type                 | Additional Information                                                           |
-| -------------------- | -------------------------------------------------------------------------------- |
-| Groups               | -                                                                                |
-| Required Actions     | You have to copy the default one to you import json.                             |
-| Client Scopes        | -                                                                                |
-| Scope Mappings       | -                                                                                |
-| Components           | You have to copy the default components to you import json.                      |
-| Sub Components       | You have to copy the default components to you import json.                      |
-| Authentication Flows | You have to copy the default components to you import json, expect bulitin flows |
+| Type                        | Additional Information                                                           | Property Name               |
+| --------------------------- | -------------------------------------------------------------------------------- | --------------------------- |
+| Groups                      | -                                                                                | `group`                     |
+| Required Actions            | You have to copy the default one to you import json.                             | `required-action`           |
+| Client Scopes               | -                                                                                | `client-scope`              |
+| Scope Mappings              | -                                                                                | `scope-mapping`             |
+| Components                  | You have to copy the default components to you import json.                      | `component`                 |
+| Sub Components              | You have to copy the default components to you import json.                      | `sub-component`             |
+| Authentication Flows        | You have to copy the default components to you import json, expect bulitin flows | `authentication-flow`       |
+| Identity Providers          | -                                                                                | `identity-provider`         |
+| Identity Provider Mappers   | -                                                                                | `identity-provider-mapper`  |
 
 ## Disable deletion of managed entities
 

--- a/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
+++ b/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
@@ -119,11 +119,18 @@ public class ImportConfigProperties {
         @NotNull
         private final ImportManagedPropertiesValues authenticationFlow;
 
+        @NotNull
+        private final ImportManagedPropertiesValues identityProvider;
+
+        @NotNull
+        private final ImportManagedPropertiesValues identityProviderMapper;
+
         public ImportManagedProperties(
                 ImportManagedPropertiesValues requiredAction, ImportManagedPropertiesValues group,
                 ImportManagedPropertiesValues clientScope, ImportManagedPropertiesValues scopeMapping,
                 ImportManagedPropertiesValues component, ImportManagedPropertiesValues subComponent,
-                ImportManagedPropertiesValues authenticationFlow) {
+                ImportManagedPropertiesValues authenticationFlow, ImportManagedPropertiesValues identityProvider,
+                ImportManagedPropertiesValues identityProviderMapper) {
             this.requiredAction = requiredAction;
             this.group = group;
             this.clientScope = clientScope;
@@ -131,6 +138,8 @@ public class ImportConfigProperties {
             this.component = component;
             this.subComponent = subComponent;
             this.authenticationFlow = authenticationFlow;
+            this.identityProvider = identityProvider;
+            this.identityProviderMapper = identityProviderMapper;
         }
 
         public ImportManagedPropertiesValues getRequiredAction() {
@@ -160,6 +169,10 @@ public class ImportConfigProperties {
         public ImportManagedPropertiesValues getGroup() {
             return group;
         }
+
+        public ImportManagedPropertiesValues getIdentityProvider() { return identityProvider; }
+
+        public ImportManagedPropertiesValues getIdentityProviderMapper() { return identityProviderMapper; }
 
         public enum ImportManagedPropertiesValues {
             FULL,

--- a/src/main/java/de/adorsys/keycloak/config/repository/IdentityProviderMapperRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/IdentityProviderMapperRepository.java
@@ -1,0 +1,91 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2020 adorsys GmbH & Co. KG @ https://adorsys.de
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.repository;
+
+import de.adorsys.keycloak.config.util.ResponseUtil;
+import de.adorsys.keycloak.config.util.StreamUtil;
+import org.keycloak.admin.client.resource.IdentityProvidersResource;
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class IdentityProviderMapperRepository {
+
+    private final RealmRepository realmRepository;
+
+    @Autowired
+    public IdentityProviderMapperRepository(RealmRepository realmRepository) {
+        this.realmRepository = realmRepository;
+    }
+
+    public Optional<IdentityProviderMapperRepresentation> tryToFindIdentityProviderMapper(String realm, String identityProviderAlias, String name) {
+        return loadIdentityProviderMapperByName(realm, identityProviderAlias, name);
+    }
+
+    public IdentityProviderMapperRepresentation getIdentityProviderMapperByName(String realm, String identityProviderAlias, String name) {
+        Optional<IdentityProviderMapperRepresentation> maybeIdentityProviderMapper = loadIdentityProviderMapperByName(realm, identityProviderAlias, name);
+
+        return maybeIdentityProviderMapper.orElse(null);
+    }
+
+    public List<IdentityProviderMapperRepresentation> getIdentityProviderMappers(String realm) {
+        List<IdentityProviderMapperRepresentation> mappers = new ArrayList<>();
+        IdentityProvidersResource identityProvidersResource = realmRepository.loadRealm(realm).identityProviders();
+        List<IdentityProviderRepresentation> identityProviders = identityProvidersResource.findAll();
+
+        for(IdentityProviderRepresentation identityProvider : identityProviders) {
+            mappers.addAll(identityProvidersResource.get(identityProvider.getAlias()).getMappers());
+        }
+        return mappers;
+    }
+
+    public void createIdentityProviderMapper(String realm, IdentityProviderMapperRepresentation identityProviderMapper) {
+        IdentityProvidersResource identityProvidersResource = realmRepository.loadRealm(realm).identityProviders();
+
+        Response response = identityProvidersResource.get(identityProviderMapper.getIdentityProviderAlias()).addMapper(identityProviderMapper);
+        ResponseUtil.throwOnError(response);
+    }
+
+    public void updateIdentityProviderMapper(String realm, IdentityProviderMapperRepresentation identityProviderMapperToUpdate) {
+        IdentityProvidersResource identityProvidersResource = realmRepository.loadRealm(realm).identityProviders();
+
+        identityProvidersResource.get(identityProviderMapperToUpdate.getIdentityProviderAlias()).update(identityProviderMapperToUpdate.getId(), identityProviderMapperToUpdate);
+    }
+
+    public void deleteIdentityProviderMapper(String realm, IdentityProviderMapperRepresentation identityProviderMapperToDelete) {
+        IdentityProvidersResource identityProvidersResource = realmRepository.loadRealm(realm).identityProviders();
+        String identityProviderAlias = identityProviderMapperToDelete.getIdentityProviderAlias();
+
+        identityProvidersResource.get(identityProviderAlias).delete(identityProviderMapperToDelete.getId());
+    }
+
+    private Optional<IdentityProviderMapperRepresentation> loadIdentityProviderMapperByName(String realm, String identityProviderAlias, String name) {
+        return StreamUtil.collectionAsStream(realmRepository.get(realm).getIdentityProviderMappers()).filter(m -> m.getName().equals(name) && m.getIdentityProviderAlias().equals(identityProviderAlias)).findFirst();
+    }
+
+}

--- a/src/main/java/de/adorsys/keycloak/config/service/IdentityProviderImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/IdentityProviderImportService.java
@@ -21,7 +21,11 @@
 package de.adorsys.keycloak.config.service;
 
 import de.adorsys.keycloak.config.model.RealmImport;
+import de.adorsys.keycloak.config.properties.ImportConfigProperties;
+import de.adorsys.keycloak.config.repository.IdentityProviderMapperRepository;
 import de.adorsys.keycloak.config.repository.IdentityProviderRepository;
+import de.adorsys.keycloak.config.util.CloneUtil;
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -36,24 +41,43 @@ public class IdentityProviderImportService {
     private static final Logger logger = LoggerFactory.getLogger(IdentityProviderImportService.class);
 
     private final IdentityProviderRepository identityProviderRepository;
+    private final IdentityProviderMapperRepository identityProviderMapperRepository;
+    private final ImportConfigProperties importConfigProperties;
 
     @Autowired
-    public IdentityProviderImportService(
-            IdentityProviderRepository identityProviderRepository
-    ) {
+    public IdentityProviderImportService(IdentityProviderRepository identityProviderRepository, IdentityProviderMapperRepository identityProviderMapperRepository, ImportConfigProperties importConfigProperties) {
         this.identityProviderRepository = identityProviderRepository;
+        this.identityProviderMapperRepository = identityProviderMapperRepository;
+        this.importConfigProperties = importConfigProperties;
     }
 
     public void doImport(RealmImport realmImport) {
-        createOrUpdateIdentityProviders(realmImport);
+        createOrUpdateOrDeleteIdentityProviders(realmImport);
+        createOrUpdateOrDeleteIdentityProviderMappers(realmImport);
     }
 
-    private void createOrUpdateIdentityProviders(RealmImport realmImport) {
+    private void createOrUpdateOrDeleteIdentityProviders(RealmImport realmImport) {
+        String realm = realmImport.getRealm();
         List<IdentityProviderRepresentation> identityProviders = realmImport.getIdentityProviders();
+        List<IdentityProviderRepresentation> existingIdentityProviders = identityProviderRepository.getIdentityProviders(realm);
+
         if (identityProviders == null) return;
+
+        if (importConfigProperties.getManaged().getIdentityProvider() == ImportConfigProperties.ImportManagedProperties.ImportManagedPropertiesValues.FULL) {
+            deleteIdentityProvidersMissingInImport(realm, identityProviders, existingIdentityProviders);
+        }
 
         for (IdentityProviderRepresentation identityProvider : identityProviders) {
             createOrUpdateIdentityProvider(realmImport, identityProvider);
+        }
+    }
+
+    private void deleteIdentityProvidersMissingInImport(String realm, List<IdentityProviderRepresentation> identityProviders, List<IdentityProviderRepresentation> existingIdentityProviders) {
+        for (IdentityProviderRepresentation identityProvider : existingIdentityProviders) {
+            if(!hasIdentityProviderWithAlias(identityProviders, identityProvider.getAlias())) {
+                logger.debug("Delete identityProvider '{}' in realm '{}'", identityProvider.getAlias(), realm);
+                identityProviderRepository.deleteIdentityProvider(realm, identityProvider);
+            }
         }
     }
 
@@ -64,11 +88,94 @@ public class IdentityProviderImportService {
         Optional<IdentityProviderRepresentation> maybeIdentityProvider = identityProviderRepository.tryToFindIdentityProvider(realm, identityProviderName);
 
         if (maybeIdentityProvider.isPresent()) {
-            logger.debug("Update identityProvider '{}' in realm '{}'", identityProviderName, realm);
-            identityProviderRepository.updateIdentityProvider(realm, identityProvider);
+            updateIdentityProviderIfNecessary(realm, identityProvider);
         } else {
             logger.debug("Create identityProvider '{}' in realm '{}'", identityProviderName, realm);
             identityProviderRepository.createIdentityProvider(realm, identityProvider);
         }
     }
+
+    private void updateIdentityProviderIfNecessary(String realm, IdentityProviderRepresentation identityProvider) {
+        IdentityProviderRepresentation existingIdentityProvider = identityProviderRepository.getIdentityProviderByAlias(realm, identityProvider.getAlias());
+        IdentityProviderRepresentation patchedIdentityProvider = CloneUtil.patch(existingIdentityProvider, identityProvider);
+        String identityProviderAlias = existingIdentityProvider.getAlias();
+
+        if (isIdentityProviderEqual(existingIdentityProvider, patchedIdentityProvider)) {
+            logger.debug("No need to update identityProvider '{}' in realm '{}'", identityProviderAlias, realm);
+        } else {
+            logger.debug("Update identityProvider '{}' in realm '{}'", identityProviderAlias, realm);
+            identityProviderRepository.updateIdentityProvider(realm, patchedIdentityProvider);
+        }
+    }
+
+    private boolean isIdentityProviderEqual(IdentityProviderRepresentation existingIdentityProvider, IdentityProviderRepresentation patchedIdentityProvider) {
+        return CloneUtil.deepEquals(existingIdentityProvider, patchedIdentityProvider);
+    }
+
+    private boolean hasIdentityProviderWithAlias(List<IdentityProviderRepresentation> identityProviders, String identityProviderAlias) {
+        return identityProviders.stream().anyMatch(idp -> Objects.equals(idp.getAlias(), identityProviderAlias));
+    }
+
+    private void createOrUpdateOrDeleteIdentityProviderMappers(RealmImport realmImport) {
+        String realm = realmImport.getRealm();
+        List<IdentityProviderMapperRepresentation> identityProviderMappers = realmImport.getIdentityProviderMappers();
+        List<IdentityProviderMapperRepresentation> existingIdentityProviderMappers = identityProviderMapperRepository.getIdentityProviderMappers(realm);
+
+        if (identityProviderMappers == null) return;
+
+        if (importConfigProperties.getManaged().getIdentityProviderMapper() == ImportConfigProperties.ImportManagedProperties.ImportManagedPropertiesValues.FULL) {
+            deleteIdentityProviderMappersMissingInImport(realm, identityProviderMappers, existingIdentityProviderMappers);
+        }
+
+        for (IdentityProviderMapperRepresentation identityProviderMapper : identityProviderMappers) {
+            createOrUpdateIdentityProviderMapper(realmImport, identityProviderMapper);
+        }
+    }
+
+    private void createOrUpdateIdentityProviderMapper(RealmImport realmImport, IdentityProviderMapperRepresentation identityProviderMapper) {
+        String identityProviderMapperName = identityProviderMapper.getName();
+        String realm = realmImport.getRealm();
+
+        Optional<IdentityProviderMapperRepresentation> maybeIdentityProviderMapper = identityProviderMapperRepository.tryToFindIdentityProviderMapper(realm, identityProviderMapper.getIdentityProviderAlias(), identityProviderMapperName);
+
+        if (maybeIdentityProviderMapper.isPresent()) {
+            updateIdentityProviderMapperIfNecessary(realm, identityProviderMapper);
+        } else {
+            logger.debug("Create identityProviderMapper '{}' in realm '{}'", identityProviderMapperName, realm);
+            identityProviderMapperRepository.createIdentityProviderMapper(realm, identityProviderMapper);
+        }
+    }
+
+    private void updateIdentityProviderMapperIfNecessary(String realm, IdentityProviderMapperRepresentation identityProviderMapper) {
+        IdentityProviderMapperRepresentation existingIdentityProviderMapper = identityProviderMapperRepository.getIdentityProviderMapperByName(realm, identityProviderMapper.getIdentityProviderAlias(), identityProviderMapper.getName());
+        IdentityProviderMapperRepresentation patchedIdentityProviderMapper = CloneUtil.patch(existingIdentityProviderMapper, identityProviderMapper);
+        String identityProviderMapperName = existingIdentityProviderMapper.getName();
+        String identityProviderAlias = existingIdentityProviderMapper.getIdentityProviderAlias();
+
+        if (isIdentityProviderMapperEqual(existingIdentityProviderMapper, patchedIdentityProviderMapper)) {
+            logger.debug("No need to update identityProviderMapper for identityProvider '{}' in realm '{}' in realm '{}'", identityProviderMapperName, identityProviderAlias, realm);
+        } else {
+            logger.debug("Update identityProviderMapper '{}' for identityProvider '{}' in realm '{}'", identityProviderMapperName, identityProviderAlias, realm);
+            identityProviderMapperRepository.updateIdentityProviderMapper(realm, patchedIdentityProviderMapper);
+        }
+    }
+
+    private boolean isIdentityProviderMapperEqual(IdentityProviderMapperRepresentation existingIdentityProviderMapper, IdentityProviderMapperRepresentation patchedIdentityProviderMapper) {
+        return CloneUtil.deepEquals(existingIdentityProviderMapper, patchedIdentityProviderMapper);
+    }
+
+
+    private void deleteIdentityProviderMappersMissingInImport(String realm, List<IdentityProviderMapperRepresentation> identityProviderMappers, List<IdentityProviderMapperRepresentation> existingIdentityProviderMappers) {
+        for (IdentityProviderMapperRepresentation identityProviderMapper : existingIdentityProviderMappers) {
+            if(!hasIdentityProviderMapperWithNameForAlias(identityProviderMappers, identityProviderMapper)) {
+                logger.debug("Delete identityProviderMapper '{}' in realm '{}'", identityProviderMapper.getName(), realm);
+                identityProviderMapperRepository.deleteIdentityProviderMapper(realm, identityProviderMapper);
+            }
+        }
+    }
+
+    private boolean hasIdentityProviderMapperWithNameForAlias(List<IdentityProviderMapperRepresentation> identityProviderMappers, IdentityProviderMapperRepresentation identityProviderMapper) {
+        return identityProviderMappers.stream().anyMatch(idpm -> Objects.equals(idpm.getName(), identityProviderMapper.getName()) && Objects.equals(idpm.getIdentityProviderAlias(), identityProviderMapper.getIdentityProviderAlias()));
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,5 @@ import.managed.client-scope=full
 import.managed.scope-mapping=full
 import.managed.component=full
 import.managed.sub-component=full
+import.managed.identity-provider=full
+import.managed.identity-provider-mapper=full

--- a/src/test/java/de/adorsys/keycloak/config/ImportManagedNoDeleteIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/ImportManagedNoDeleteIT.java
@@ -40,6 +40,8 @@ import static org.hamcrest.Matchers.hasSize;
         "import.managed.scope-mapping=no-delete",
         "import.managed.component=no-delete",
         "import.managed.sub-component=no-delete",
+        "import.managed.identity-provider=no-delete",
+        "import.managed.identity-provider-mapper=no-delete",
 })
 class ImportManagedNoDeleteIT extends AbstractImportTest {
     private static final String REALM_NAME = "realmWithNoDelete";
@@ -112,5 +114,19 @@ class ImportManagedNoDeleteIT extends AbstractImportTest {
                 .filter((authenticationFlow) -> authenticationFlowsList.contains(authenticationFlow.getAlias()))
                 .collect(Collectors.toList());
         assertThat(createdAuthenticationFlows, hasSize(3));
+
+        List<String> identityProviderList = Arrays.asList("my-first-idp", "my-second-idp");
+        List<IdentityProviderRepresentation> createdIdentityProviders = createdRealm.getIdentityProviders()
+                .stream()
+                .filter((identityProvider) -> identityProviderList.contains(identityProvider.getAlias()))
+                .collect(Collectors.toList());
+        assertThat(createdIdentityProviders, hasSize(2));
+
+        List<String> identityProviderMapperList = Arrays.asList("my-first-idp-mapper", "my-second-idp-mapper");
+        List<IdentityProviderMapperRepresentation> createdIdentityProviderMappers = createdRealm.getIdentityProviderMappers()
+                .stream()
+                .filter((identityProviderMapper) -> identityProviderMapperList.contains(identityProviderMapper.getName()))
+                .collect(Collectors.toList());
+        assertThat(createdIdentityProviderMappers, hasSize(2));
     }
 }

--- a/src/test/java/de/adorsys/keycloak/config/properties/ImportConfigPropertiesTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/properties/ImportConfigPropertiesTest.java
@@ -50,6 +50,8 @@ import static org.hamcrest.core.Is.is;
         "import.managed.scope-mapping=no-delete",
         "import.managed.component=no-delete",
         "import.managed.sub-component=no-delete",
+        "import.managed.identity-provider=no-delete",
+        "import.managed.identity-provider-mapper=no-delete"
 })
 class ImportConfigPropertiesTest {
 
@@ -71,6 +73,8 @@ class ImportConfigPropertiesTest {
         assertThat(properties.getManaged().getScopeMapping(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getComponent(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getSubComponent(), is(ImportManagedPropertiesValues.NO_DELETE));
+        assertThat(properties.getManaged().getIdentityProvider(), is(ImportManagedPropertiesValues.NO_DELETE));
+        assertThat(properties.getManaged().getIdentityProviderMapper(), is(ImportManagedPropertiesValues.NO_DELETE));
     }
 
     @EnableConfigurationProperties(ImportConfigProperties.class)

--- a/src/test/java/de/adorsys/keycloak/config/test/util/KeycloakVersion.java
+++ b/src/test/java/de/adorsys/keycloak/config/test/util/KeycloakVersion.java
@@ -1,0 +1,36 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2020 adorsys GmbH & Co. KG @ https://adorsys.de
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.test.util;
+
+public class KeycloakVersion {
+
+    private static final String KEYCLOAK_VERSION_ENV_NAME = "KEYCLOAK_VERSION";
+
+    public static boolean isKeycloak8() {
+        String version = getKeycloakVersion();
+        return version != null && version.startsWith("8.");
+    }
+
+    private static String getKeycloakVersion() {
+        return System.getProperty(KEYCLOAK_VERSION_ENV_NAME);
+    }
+
+}

--- a/src/test/java/de/adorsys/keycloak/config/test/util/KeycloakVersion.java
+++ b/src/test/java/de/adorsys/keycloak/config/test/util/KeycloakVersion.java
@@ -22,7 +22,7 @@ package de.adorsys.keycloak.config.test.util;
 
 public class KeycloakVersion {
 
-    private static final String KEYCLOAK_VERSION_ENV_NAME = "KEYCLOAK_VERSION";
+    private static final String KEYCLOAK_VERSION_PROPERTY_NAME = "keycloak.version";
 
     public static boolean isKeycloak8() {
         String version = getKeycloakVersion();
@@ -30,7 +30,7 @@ public class KeycloakVersion {
     }
 
     private static String getKeycloakVersion() {
-        return System.getProperty(KEYCLOAK_VERSION_ENV_NAME);
+        return System.getProperty(KEYCLOAK_VERSION_PROPERTY_NAME);
     }
 
 }

--- a/src/test/resources/import-files/identity-providers/3_create_identity-provider_for_keycloak-oidc.json
+++ b/src/test/resources/import-files/identity-providers/3_create_identity-provider_for_keycloak-oidc.json
@@ -1,0 +1,31 @@
+{
+  "enabled": true,
+  "realm": "realmWithIdentityProviders",
+  "identityProviders": [
+    {
+      "alias": "keycloak-oidc",
+      "displayName": "my-keycloak-oidc",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "example-client-id",
+        "tokenUrl": "https://example.com/protocol/openid-connect/token",
+        "authorizationUrl": "https://example.com/protocol/openid-connect/auth",
+        "clientAuthMethod": "client_secret_post",
+        "logoutUrl": "https://example.com/protocol/openid-connect/logout",
+        "syncMode": "FORCE",
+        "clientSecret": "example-client-secret",
+        "backchannelSupported": "true",
+        "defaultScope": "",
+        "guiOrder": "0",
+        "useJwksUrl": "true"
+      }
+    }
+  ]
+}

--- a/src/test/resources/import-files/identity-providers/4_update_identity-provider_for_keycloak-oidc.json
+++ b/src/test/resources/import-files/identity-providers/4_update_identity-provider_for_keycloak-oidc.json
@@ -1,0 +1,31 @@
+{
+  "enabled": true,
+  "realm": "realmWithIdentityProviders",
+  "identityProviders": [
+    {
+      "alias": "keycloak-oidc",
+      "displayName": "changed-my-keycloak-oidc",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "changed-example-client-id",
+        "tokenUrl": "https://example.com/protocol/openid-connect/token",
+        "authorizationUrl": "https://example.com/protocol/openid-connect/auth",
+        "clientAuthMethod": "client_secret_post",
+        "logoutUrl": "https://example.com/protocol/openid-connect/logout",
+        "syncMode": "FORCE",
+        "clientSecret": "example-client-secret",
+        "backchannelSupported": "true",
+        "defaultScope": "",
+        "guiOrder": "0",
+        "useJwksUrl": "true"
+      }
+    }
+  ]
+}

--- a/src/test/resources/import-files/identity-providers/5_update_identity-provider_for_keycloak-oidc_with_mapper.json
+++ b/src/test/resources/import-files/identity-providers/5_update_identity-provider_for_keycloak-oidc_with_mapper.json
@@ -1,0 +1,43 @@
+{
+  "enabled": true,
+  "realm": "realmWithIdentityProviders",
+  "identityProviders": [
+    {
+      "alias": "keycloak-oidc",
+      "displayName": "my-keycloak-oidc",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "example-client-id",
+        "tokenUrl": "https://example.com/protocol/openid-connect/token",
+        "authorizationUrl": "https://example.com/protocol/openid-connect/auth",
+        "clientAuthMethod": "client_secret_post",
+        "logoutUrl": "https://example.com/protocol/openid-connect/logout",
+        "syncMode": "FORCE",
+        "clientSecret": "example-client-secret",
+        "backchannelSupported": "true",
+        "defaultScope": "",
+        "guiOrder": "0",
+        "useJwksUrl": "true"
+      }
+    }
+  ],
+  "identityProviderMappers": [
+    {
+      "name": "my-username-mapper",
+      "identityProviderAlias": "keycloak-oidc",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "template": "${ALIAS}.${CLAIM.email}",
+        "syncMode": "INHERIT"
+      }
+    }
+  ]
+}

--- a/src/test/resources/import-files/identity-providers/6_update_identity-provider_for_keycloak-oidc_with_updated_mapper.json
+++ b/src/test/resources/import-files/identity-providers/6_update_identity-provider_for_keycloak-oidc_with_updated_mapper.json
@@ -1,0 +1,43 @@
+{
+  "enabled": true,
+  "realm": "realmWithIdentityProviders",
+  "identityProviders": [
+    {
+      "alias": "keycloak-oidc",
+      "displayName": "my-keycloak-oidc",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "example-client-id",
+        "tokenUrl": "https://example.com/protocol/openid-connect/token",
+        "authorizationUrl": "https://example.com/protocol/openid-connect/auth",
+        "clientAuthMethod": "client_secret_post",
+        "logoutUrl": "https://example.com/protocol/openid-connect/logout",
+        "syncMode": "FORCE",
+        "clientSecret": "example-client-secret",
+        "backchannelSupported": "true",
+        "defaultScope": "",
+        "guiOrder": "0",
+        "useJwksUrl": "true"
+      }
+    }
+  ],
+  "identityProviderMappers": [
+    {
+      "name": "my-username-mapper",
+      "identityProviderAlias": "keycloak-oidc",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "template": "${CLAIM.email}",
+        "syncMode": "FORCE"
+      }
+    }
+  ]
+}

--- a/src/test/resources/import-files/identity-providers/7_update_identity-provider_for_keycloak-oidc_with_replaced_mapper.json
+++ b/src/test/resources/import-files/identity-providers/7_update_identity-provider_for_keycloak-oidc_with_replaced_mapper.json
@@ -1,0 +1,43 @@
+{
+  "enabled": true,
+  "realm": "realmWithIdentityProviders",
+  "identityProviders": [
+    {
+      "alias": "keycloak-oidc",
+      "displayName": "my-keycloak-oidc",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "example-client-id",
+        "tokenUrl": "https://example.com/protocol/openid-connect/token",
+        "authorizationUrl": "https://example.com/protocol/openid-connect/auth",
+        "clientAuthMethod": "client_secret_post",
+        "logoutUrl": "https://example.com/protocol/openid-connect/logout",
+        "syncMode": "FORCE",
+        "clientSecret": "example-client-secret",
+        "backchannelSupported": "true",
+        "defaultScope": "",
+        "guiOrder": "0",
+        "useJwksUrl": "true"
+      }
+    }
+  ],
+  "identityProviderMappers": [
+    {
+      "name": "my-changed-username-mapper",
+      "identityProviderAlias": "keycloak-oidc",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "template": "${CLAIM.email}",
+        "syncMode": "FORCE"
+      }
+    }
+  ]
+}

--- a/src/test/resources/import-files/identity-providers/8_update_identity-provider_for_keycloak-oidc_with_deleted_mapper.json
+++ b/src/test/resources/import-files/identity-providers/8_update_identity-provider_for_keycloak-oidc_with_deleted_mapper.json
@@ -1,0 +1,34 @@
+{
+  "enabled": true,
+  "realm": "realmWithIdentityProviders",
+  "identityProviders": [
+    {
+      "alias": "keycloak-oidc",
+      "displayName": "my-keycloak-oidc",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "example-client-id",
+        "tokenUrl": "https://example.com/protocol/openid-connect/token",
+        "authorizationUrl": "https://example.com/protocol/openid-connect/auth",
+        "clientAuthMethod": "client_secret_post",
+        "logoutUrl": "https://example.com/protocol/openid-connect/logout",
+        "syncMode": "FORCE",
+        "clientSecret": "example-client-secret",
+        "backchannelSupported": "true",
+        "defaultScope": "",
+        "guiOrder": "0",
+        "useJwksUrl": "true"
+      }
+    }
+  ],
+  "identityProviderMappers": [
+  ]
+}

--- a/src/test/resources/import-files/identity-providers/9_delete_identity-provider_for_keycloak-oidc.json
+++ b/src/test/resources/import-files/identity-providers/9_delete_identity-provider_for_keycloak-oidc.json
@@ -1,0 +1,5 @@
+{
+  "enabled": true,
+  "realm": "realmWithIdentityProviders",
+  "identityProviders": []
+}

--- a/src/test/resources/import-files/managed-no-delete/0_create_simple-realm.json
+++ b/src/test/resources/import-files/managed-no-delete/0_create_simple-realm.json
@@ -308,5 +308,79 @@
         }
       }
     ]
-  }
+  },
+  "identityProviders": [
+    {
+      "alias": "my-first-idp",
+      "displayName": "my-first-idp",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "example-client-id",
+        "tokenUrl": "https://example.com/protocol/openid-connect/token",
+        "authorizationUrl": "https://example.com/protocol/openid-connect/auth",
+        "clientAuthMethod": "client_secret_post",
+        "logoutUrl": "https://example.com/protocol/openid-connect/logout",
+        "syncMode": "FORCE",
+        "clientSecret": "example-client-secret",
+        "backchannelSupported": "true",
+        "defaultScope": "",
+        "guiOrder": "0",
+        "useJwksUrl": "true"
+      }
+    },
+    {
+      "alias": "my-second-idp",
+      "displayName": "my-second-idp",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "example-client-id",
+        "tokenUrl": "https://example.com/protocol/openid-connect/token",
+        "authorizationUrl": "https://example.com/protocol/openid-connect/auth",
+        "clientAuthMethod": "client_secret_post",
+        "logoutUrl": "https://example.com/protocol/openid-connect/logout",
+        "syncMode": "FORCE",
+        "clientSecret": "example-client-secret",
+        "backchannelSupported": "true",
+        "defaultScope": "",
+        "guiOrder": "0",
+        "useJwksUrl": "true"
+      }
+    }
+  ],
+  "identityProviderMappers": [
+    {
+      "name": "my-first-idp-mapper",
+      "identityProviderAlias": "my-first-idp",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "template": "${ALIAS}.${CLAIM.email}",
+        "syncMode": "INHERIT"
+      }
+    },
+    {
+      "name": "my-second-idp-mapper",
+      "identityProviderAlias": "my-first-idp",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "template": "${ALIAS}.${CLAIM.email}",
+        "syncMode": "INHERIT"
+      }
+    }
+  ]
 }

--- a/src/test/resources/import-files/managed-no-delete/1_update-realm_not-delete-one.json
+++ b/src/test/resources/import-files/managed-no-delete/1_update-realm_not-delete-one.json
@@ -221,5 +221,44 @@
         }
       }
     ]
-  }
+  },
+  "identityProviders": [
+    {
+      "alias": "my-first-idp",
+      "displayName": "my-first-idp",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "example-client-id",
+        "tokenUrl": "https://example.com/protocol/openid-connect/token",
+        "authorizationUrl": "https://example.com/protocol/openid-connect/auth",
+        "clientAuthMethod": "client_secret_post",
+        "logoutUrl": "https://example.com/protocol/openid-connect/logout",
+        "syncMode": "FORCE",
+        "clientSecret": "example-client-secret",
+        "backchannelSupported": "true",
+        "defaultScope": "",
+        "guiOrder": "0",
+        "useJwksUrl": "true"
+      }
+    }
+  ],
+  "identityProviderMappers": [
+    {
+      "name": "my-first-idp-mapper",
+      "identityProviderAlias": "my-first-idp",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "template": "${ALIAS}.${CLAIM.email}",
+        "syncMode": "INHERIT"
+      }
+    }
+  ]
 }

--- a/src/test/resources/import-files/managed-no-delete/2_update-realm_not-delete-all.json
+++ b/src/test/resources/import-files/managed-no-delete/2_update-realm_not-delete-all.json
@@ -6,5 +6,7 @@
   "requiredActions": [],
   "clientScopes": [],
   "scopeMappings": [],
-  "components": {}
+  "components": {},
+  "identityProviders": [],
+  "identityProviderMappers": []
 }


### PR DESCRIPTION
I added support for updating only changed IdentityProviders and the possibility to use 'managed' IdentityProvider. Furthermore I added IdentityProviderMappers (create, update, delete, managed).