### PR TITLE
fix buggy docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,4 @@ COPY ./target/keycloak-config-cli.jar /opt/
 
 USER 1001
 
-ENTRYPOINT ["/bin/sh"]
 CMD exec java $JAVA_OPTS -jar /opt/keycloak-config-cli.jar


### PR DESCRIPTION
Running `docker run -it --rm adorsys/keycloak-config-cli:latest` cause  the following error    
```                                                                                                                      
/bin/sh: 1: /bin/sh: Syntax error: ")" unexpected 
```

I'm not sure that is the correct fix but relying  on FROM entrypoint seems to fix this issue.