### PR TITLE
Allow extra volume mounts

### DIFF
--- a/contrib/charts/keycloak-config-cli/templates/job.yaml
+++ b/contrib/charts/keycloak-config-cli/templates/job.yaml
@@ -62,6 +62,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
+            {{- with .Values.extraVolumeMounts }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
       volumes:
         - name: config
           secret:
@@ -71,6 +74,9 @@ spec:
             secretName: "{{ template "keycloak-config-cli.fullname" . }}-config-realms"
             {{- end }}
             defaultMode: 0555
+        {{- with .Values.extraVolumes }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
       {{- with .Values.serviceAccount }}
       serviceAccountName: "{{ tpl . $ }}"
       {{- end }}

--- a/contrib/charts/keycloak-config-cli/values.yaml
+++ b/contrib/charts/keycloak-config-cli/values.yaml
@@ -68,3 +68,9 @@ config: {}
   #   file: <path>
 
 existingConfigSecret: ""
+
+# Add additional volumes, e. g. for custom secrets
+extraVolumes: ""
+
+# Add additional volumes mounts, e. g. for custom secrets
+extraVolumeMounts: ""


### PR DESCRIPTION
Allow for extra volume mounts. The idea is the same as used inhttps://github.com/codecentric/helm-charts/blob/master/charts/keycloak/templates/statefulset.yaml

This allows to mount for example additional secrets that can be used in the configuration (using variable substitution).