### PR TITLE
NonTopLevelFlow -> SubFlow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Cookie Management for http client to support clustered environments with cookie based sticky sessions
+- Raise an exception, if authenticator is defined for a basic-flow execution
 
 ### Changes
 

--- a/src/main/java/de/adorsys/keycloak/config/repository/AuthenticationFlowRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/AuthenticationFlowRepository.java
@@ -167,10 +167,10 @@ public class AuthenticationFlowRepository {
     public Optional<AuthenticationExecutionInfoRepresentation> searchSubFlow(
             String realmName,
             String topLevelFlowAlias,
-            String nonTopLevelFlowAlias
+            String subFlowAlias
     ) {
         logger.trace("Search non-top-level-flow '{}' in realm '{}' and top-level-flow '{}'",
-                nonTopLevelFlowAlias, realmName, topLevelFlowAlias);
+                subFlowAlias, realmName, topLevelFlowAlias);
 
         AuthenticationManagementResource flowsResource = getFlowResources(realmName);
 
@@ -178,7 +178,7 @@ public class AuthenticationFlowRepository {
                 .stream()
                 /* we have to compare the display name with the alias, because the alias property in
                  AuthenticationExecutionInfoRepresentation representations is always set to null. */
-                .filter(flow -> Objects.equals(flow.getDisplayName(), nonTopLevelFlowAlias))
+                .filter(flow -> Objects.equals(flow.getDisplayName(), subFlowAlias))
                 .findFirst();
     }
 }

--- a/src/main/java/de/adorsys/keycloak/config/repository/ExecutionFlowRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/ExecutionFlowRepository.java
@@ -130,19 +130,19 @@ public class ExecutionFlowRepository {
         }
     }
 
-    public void createNonTopLevelFlowExecution(
+    public void createSubFlowExecution(
             String realmName,
-            String nonTopLevelFlowAlias,
+            String subFlowAlias,
             Map<String, String> executionData
     ) {
         logger.trace("Create flow-execution in realm '{}' and non-top-level-flow '{}'",
-                realmName, nonTopLevelFlowAlias);
+                realmName, subFlowAlias);
 
         AuthenticationManagementResource flowsResource = authenticationFlowRepository.getFlowResources(realmName);
-        flowsResource.addExecution(nonTopLevelFlowAlias, executionData);
+        flowsResource.addExecution(subFlowAlias, executionData);
 
         logger.trace("Created flow-execution in realm '{}' and non-top-level-flow '{}'",
-                realmName, nonTopLevelFlowAlias);
+                realmName, subFlowAlias);
     }
 
     private List<AuthenticationExecutionInfoRepresentation> searchByAlias(

--- a/src/main/java/de/adorsys/keycloak/config/util/AuthenticationFlowUtil.java
+++ b/src/main/java/de/adorsys/keycloak/config/util/AuthenticationFlowUtil.java
@@ -36,30 +36,30 @@ public class AuthenticationFlowUtil {
         throw new IllegalStateException("Utility class");
     }
 
-    public static AuthenticationFlowRepresentation getNonTopLevelFlow(
+    public static AuthenticationFlowRepresentation getSubFlow(
             RealmImport realmImport,
             String alias
     ) {
-        Optional<AuthenticationFlowRepresentation> maybeNonTopLevelFlow = tryToGetNonTopLevelFlow(realmImport, alias);
+        Optional<AuthenticationFlowRepresentation> maybeSubFlow = tryToGetSubFlow(realmImport, alias);
 
-        if (!maybeNonTopLevelFlow.isPresent()) {
+        if (!maybeSubFlow.isPresent()) {
             throw new ImportProcessingException("Non-toplevel flow not found: " + alias);
         }
 
-        return maybeNonTopLevelFlow.get();
+        return maybeSubFlow.get();
     }
 
-    private static Optional<AuthenticationFlowRepresentation> tryToGetNonTopLevelFlow(
+    private static Optional<AuthenticationFlowRepresentation> tryToGetSubFlow(
             RealmImport realmImport,
             String alias
     ) {
-        return getNonTopLevelFlows(realmImport)
+        return getSubFlows(realmImport)
                 .stream()
                 .filter(f -> Objects.equals(f.getAlias(), alias))
                 .findFirst();
     }
 
-    private static List<AuthenticationFlowRepresentation> getNonTopLevelFlows(RealmImport realmImport) {
+    private static List<AuthenticationFlowRepresentation> getSubFlows(RealmImport realmImport) {
         return realmImport.getAuthenticationFlows().stream()
                 .filter(f -> !f.isTopLevel())
                 .collect(Collectors.toList());
@@ -73,7 +73,7 @@ public class AuthenticationFlowUtil {
 
 
     @SuppressWarnings("deprecation")
-    public static List<AuthenticationFlowRepresentation> getNonTopLevelFlowsForTopLevelFlow(
+    public static List<AuthenticationFlowRepresentation> getSubFlowsForTopLevelFlow(
             RealmImport realmImport,
             AuthenticationFlowRepresentation topLevelFlow
     ) {
@@ -81,7 +81,7 @@ public class AuthenticationFlowUtil {
                 .stream()
                 .filter(AbstractAuthenticationExecutionRepresentation::isAutheticatorFlow)
                 .map(AuthenticationExecutionExportRepresentation::getFlowAlias)
-                .map(alias -> getNonTopLevelFlow(realmImport, alias))
+                .map(alias -> getSubFlow(realmImport, alias))
                 .collect(Collectors.toList());
     }
 }

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
@@ -203,18 +203,18 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
         assertThat(execution.get(0).getPriority(), is(0));
         assertThat(execution.get(0).isAutheticatorFlow(), is(true));
 
-        AuthenticationFlowRepresentation nonTopLevelFlow = getAuthenticationFlow(realm, "my registration form");
-        List<AuthenticationExecutionExportRepresentation> nonTopLevelFlowExecutions = nonTopLevelFlow.getAuthenticationExecutions();
-        assertThat(nonTopLevelFlowExecutions, hasSize(2));
+        AuthenticationFlowRepresentation subFlow = getAuthenticationFlow(realm, "my registration form");
+        List<AuthenticationExecutionExportRepresentation> subFlowExecutions = subFlow.getAuthenticationExecutions();
+        assertThat(subFlowExecutions, hasSize(2));
 
-        execution = getExecutionFromFlow(nonTopLevelFlow, "registration-user-creation");
+        execution = getExecutionFromFlow(subFlow, "registration-user-creation");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("registration-user-creation"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
         assertThat(execution.get(0).getPriority(), is(0));
         assertThat(execution.get(0).isAutheticatorFlow(), is(false));
 
-        execution = getExecutionFromFlow(nonTopLevelFlow, "registration-profile-action");
+        execution = getExecutionFromFlow(subFlow, "registration-profile-action");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("registration-profile-action"));
         assertThat(execution.get(0).getRequirement(), is("DISABLED"));
@@ -227,9 +227,9 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
     void shouldFailWhenTryAddFlowWithDefectiveExecutionFlow() throws IOException {
         RealmImport foundImport = getImport("05_try_to_update_realm__add_flow_with_defective_execution_flow.json");
 
-        ImportProcessingException thrown = assertThrows(ImportProcessingException.class, () -> realmImportService.doImport(foundImport));
+        InvalidImportException thrown = assertThrows(InvalidImportException.class, () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), matchesPattern("Cannot create execution-flow 'my registration form' for top-level-flow 'my registration' in realm 'realmWithFlow':.*"));
+        assertThat(thrown.getMessage(), is("Execution property authenticator 'registration-page-form' can be only set if the sub-flow 'my registration form' type is 'form-flow'."));
     }
 
     @Test
@@ -258,19 +258,19 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
         assertThat(execution.get(0).getPriority(), is(0));
         assertThat(execution.get(0).isAutheticatorFlow(), is(true));
 
-        AuthenticationFlowRepresentation nonTopLevelFlow = getAuthenticationFlow(realm, "my registration form");
+        AuthenticationFlowRepresentation subFlow = getAuthenticationFlow(realm, "my registration form");
 
-        List<AuthenticationExecutionExportRepresentation> nonTopLevelFlowExecutions = nonTopLevelFlow.getAuthenticationExecutions();
-        assertThat(nonTopLevelFlowExecutions, hasSize(2));
+        List<AuthenticationExecutionExportRepresentation> subFlowExecutions = subFlow.getAuthenticationExecutions();
+        assertThat(subFlowExecutions, hasSize(2));
 
-        execution = getExecutionFromFlow(nonTopLevelFlow, "registration-user-creation");
+        execution = getExecutionFromFlow(subFlow, "registration-user-creation");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("registration-user-creation"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
         assertThat(execution.get(0).getPriority(), is(0));
         assertThat(execution.get(0).isAutheticatorFlow(), is(false));
 
-        execution = getExecutionFromFlow(nonTopLevelFlow, "registration-profile-action");
+        execution = getExecutionFromFlow(subFlow, "registration-profile-action");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("registration-profile-action"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
@@ -283,9 +283,9 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
     void shouldFailWhenTryToUpdateDefectiveFlowRequirementWithExecutionFlow() throws IOException {
         RealmImport foundImport = getImport("06_try_to_update_realm__change_requirement_in_defective_flow_with_execution_flow.json");
 
-        ImportProcessingException thrown = assertThrows(ImportProcessingException.class, () -> realmImportService.doImport(foundImport));
+        InvalidImportException thrown = assertThrows(InvalidImportException.class, () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), matchesPattern("Cannot create execution-flow 'my registration form' for top-level-flow 'my registration' in realm 'realmWithFlow': .*"));
+        assertThat(thrown.getMessage(), matchesPattern("Execution property authenticator 'registration-page-form' can be only set if the sub-flow 'my registration form' type is 'form-flow'."));
     }
 
     @Test
@@ -345,19 +345,19 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
         assertThat(execution.get(0).getPriority(), is(0));
         assertThat(execution.get(0).isAutheticatorFlow(), is(true));
 
-        AuthenticationFlowRepresentation nonTopLevelFlow = getAuthenticationFlow(realm, "my registration form");
+        AuthenticationFlowRepresentation subFlow = getAuthenticationFlow(realm, "my registration form");
 
-        List<AuthenticationExecutionExportRepresentation> nonTopLevelFlowExecutions = nonTopLevelFlow.getAuthenticationExecutions();
-        assertThat(nonTopLevelFlowExecutions, hasSize(2));
+        List<AuthenticationExecutionExportRepresentation> subFlowExecutions = subFlow.getAuthenticationExecutions();
+        assertThat(subFlowExecutions, hasSize(2));
 
-        execution = getExecutionFromFlow(nonTopLevelFlow, "registration-user-creation");
+        execution = getExecutionFromFlow(subFlow, "registration-user-creation");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("registration-user-creation"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
         assertThat(execution.get(0).getPriority(), is(1));
         assertThat(execution.get(0).isAutheticatorFlow(), is(false));
 
-        execution = getExecutionFromFlow(nonTopLevelFlow, "registration-profile-action");
+        execution = getExecutionFromFlow(subFlow, "registration-profile-action");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("registration-profile-action"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
@@ -592,19 +592,19 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
         assertThat(flow.isBuiltIn(), is(false));
         assertThat(flow.isTopLevel(), is(true));
 
-        AuthenticationFlowRepresentation nonTopLevelFlow = getAuthenticationFlow(realm, "my execution-flow");
+        AuthenticationFlowRepresentation subFlow = getAuthenticationFlow(realm, "my execution-flow");
 
-        List<AuthenticationExecutionExportRepresentation> nonTopLevelFlowExecutions = nonTopLevelFlow.getAuthenticationExecutions();
-        assertThat(nonTopLevelFlowExecutions, hasSize(2));
+        List<AuthenticationExecutionExportRepresentation> subFlowExecutions = subFlow.getAuthenticationExecutions();
+        assertThat(subFlowExecutions, hasSize(2));
 
-        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(nonTopLevelFlow, "auth-username-password-form");
+        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(subFlow, "auth-username-password-form");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("auth-username-password-form"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
         assertThat(execution.get(0).getPriority(), is(0));
         assertThat(execution.get(0).isAutheticatorFlow(), is(false));
 
-        execution = getExecutionFromFlow(nonTopLevelFlow, "auth-otp-form");
+        execution = getExecutionFromFlow(subFlow, "auth-otp-form");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("auth-otp-form"));
         assertThat(execution.get(0).getRequirement(), is("CONDITIONAL"));
@@ -625,19 +625,19 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
 
     @Test
     @Order(26)
-    void shouldUpdateNonTopLevelFlowWithPseudoId() throws IOException {
+    void shouldUpdateSubFlowWithPseudoId() throws IOException {
         doImport("26_update_realm__update-non-top-level-flow-with-pseudo-id.json");
 
         RealmRepresentation realm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
 
-        AuthenticationFlowRepresentation nonTopLevelFlow = getAuthenticationFlow(realm, "my registration form");
-        assertThat(nonTopLevelFlow.getDescription(), is("My registration form with pseudo-id"));
+        AuthenticationFlowRepresentation subFlow = getAuthenticationFlow(realm, "my registration form");
+        assertThat(subFlow.getDescription(), is("My registration form with pseudo-id"));
     }
 
     @Test
     @Order(27)
     @DisabledIfSystemProperty(named = "keycloak.dockerImage", matches = ".*/keycloak-x")
-    void shouldNotUpdateNonTopLevelFlowWithPseudoId() throws IOException {
+    void shouldNotUpdateSubFlowWithPseudoId() throws IOException {
         RealmImport foundImport = getImport("27_update_realm__try-to-update-non-top-level-flow-with-pseudo-id.json");
 
         ImportProcessingException thrown = assertThrows(ImportProcessingException.class, () -> realmImportService.doImport(foundImport));
@@ -648,7 +648,7 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
     @Test
     @Order(28)
         //@DisabledIfSystemProperty(named = "keycloak.dockerImage", matches = ".*/keycloak-x")
-    void shouldUpdateNonTopLevelFlowWithPseudoIdAndReUseTempFlow() throws IOException {
+    void shouldUpdateSubFlowWithPseudoIdAndReUseTempFlow() throws IOException {
         doImport("28_update_realm__update-non-top-level-flow-with-pseudo-id.json");
 
         RealmRepresentation realm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
@@ -832,7 +832,7 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
 
     @Test
     @Order(43)
-    void shouldUpdateNonTopLevelBuiltinFLow() throws IOException {
+    void shouldUpdateSubBuiltinFLow() throws IOException {
         doImport("43_update_realm__update_builtin-non-top-level-flow.json");
 
         RealmRepresentation realm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
@@ -899,7 +899,7 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
 
     @Test
     @Order(50)
-    void shouldRemoveNonTopLevelFlow() throws IOException {
+    void shouldRemoveSubFlow() throws IOException {
         doImport("50_update_realm__update-remove-non-top-level-flow.json");
 
         RealmRepresentation realm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
@@ -941,19 +941,19 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
         assertThat(execution.get(0).getPriority(), is(0));
         assertThat(execution.get(0).isAutheticatorFlow(), is(true));
 
-        AuthenticationFlowRepresentation nonTopLevelFlow = getAuthenticationFlow(realm, "my registration form");
+        AuthenticationFlowRepresentation subFlow = getAuthenticationFlow(realm, "my registration form");
 
-        List<AuthenticationExecutionExportRepresentation> nonTopLevelFlowExecutions = nonTopLevelFlow.getAuthenticationExecutions();
-        assertThat(nonTopLevelFlowExecutions, hasSize(2));
+        List<AuthenticationExecutionExportRepresentation> subFlowExecutions = subFlow.getAuthenticationExecutions();
+        assertThat(subFlowExecutions, hasSize(2));
 
-        execution = getExecutionFromFlow(nonTopLevelFlow, "registration-profile-action");
+        execution = getExecutionFromFlow(subFlow, "registration-profile-action");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("registration-profile-action"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
         assertThat(execution.get(0).getPriority(), is(0));
         assertThat(execution.get(0).isAutheticatorFlow(), is(false));
 
-        execution = getExecutionFromFlow(nonTopLevelFlow, "registration-user-creation");
+        execution = getExecutionFromFlow(subFlow, "registration-user-creation");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("registration-user-creation"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
@@ -1004,19 +1004,19 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
         assertThat(execution.get(0).getPriority(), is(0));
         assertThat(execution.get(0).isAutheticatorFlow(), is(true));
 
-        AuthenticationFlowRepresentation nonTopLevelFlow = getAuthenticationFlow(realm, "my registration form");
+        AuthenticationFlowRepresentation subFlow = getAuthenticationFlow(realm, "my registration form");
 
-        List<AuthenticationExecutionExportRepresentation> nonTopLevelFlowExecutions = nonTopLevelFlow.getAuthenticationExecutions();
-        assertThat(nonTopLevelFlowExecutions, hasSize(2));
+        List<AuthenticationExecutionExportRepresentation> subFlowExecutions = subFlow.getAuthenticationExecutions();
+        assertThat(subFlowExecutions, hasSize(2));
 
-        execution = getExecutionFromFlow(nonTopLevelFlow, "registration-profile-action");
+        execution = getExecutionFromFlow(subFlow, "registration-profile-action");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("registration-profile-action"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
         assertThat(execution.get(0).getPriority(), is(0));
         assertThat(execution.get(0).isAutheticatorFlow(), is(false));
 
-        execution = getExecutionFromFlow(nonTopLevelFlow, "registration-user-creation");
+        execution = getExecutionFromFlow(subFlow, "registration-user-creation");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("registration-user-creation"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
@@ -1123,6 +1123,16 @@ class ImportAuthenticationFlowsIT extends AbstractImportTest {
 
         AuthenticationFlowRepresentation flow = getAuthenticationFlow(realm, "my-first-broker-login");
         assertThat(flow.getDescription(), is("custom changed first broker login"));
+    }
+
+    @Test
+    @Order(64)
+    void shouldNotUpdateFlowWithAuthenticatorOnBasicFlow() throws IOException {
+        RealmImport foundImport = getImport("63_update-realm__try-to-set-authenticator-basic-flow.json");
+
+        InvalidImportException thrown = assertThrows(InvalidImportException.class, () -> realmImportService.doImport(foundImport));
+
+        assertThat(thrown.getMessage(), is("Execution property authenticator 'registration-page-form' can be only set if the sub-flow 'JToken Conditional' type is 'form-flow'."));
     }
 
     private List<AuthenticationExecutionExportRepresentation> getExecutionFromFlow(AuthenticationFlowRepresentation flow, String executionAuthenticator) {

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticatorConfigIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticatorConfigIT.java
@@ -104,7 +104,7 @@ class ImportAuthenticatorConfigIT extends AbstractImportTest {
 
     @Test
     @Order(3)
-    void shouldUpdateRealmCreateFlowAuthConfigInsideNonTopLevelFlow() throws IOException {
+    void shouldUpdateRealmCreateFlowAuthConfigInsideSubFlow() throws IOException {
         doImport("3_update_realm__create_flow_auth_config_inside_non_top_level_flow.json");
 
         RealmRepresentation updatedRealm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
@@ -120,7 +120,7 @@ class ImportAuthenticatorConfigIT extends AbstractImportTest {
 
     @Test
     @Order(4)
-    void shouldUpdateRealmUpdateFlowAuthConfigInsideNonTopLevelFlow() throws IOException {
+    void shouldUpdateRealmUpdateFlowAuthConfigInsideSubFlow() throws IOException {
         doImport("4_update_realm__update_flow_auth_config_inside_non_top_level_flow.json");
 
         RealmRepresentation updatedRealm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
@@ -136,7 +136,7 @@ class ImportAuthenticatorConfigIT extends AbstractImportTest {
 
     @Test
     @Order(5)
-    void shouldUpdateRealmDeleteFlowAuthConfigInsideNonTopLevelFlow() throws IOException {
+    void shouldUpdateRealmDeleteFlowAuthConfigInsideSubFlow() throws IOException {
         doImport("5_update_realm__delete_flow_auth_config_inside_non_top_level_flow.json");
 
         RealmRepresentation updatedRealm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
@@ -150,7 +150,7 @@ class ImportAuthenticatorConfigIT extends AbstractImportTest {
 
     @Test
     @Order(6)
-    void shouldUpdateRealmCreateFlowAuthConfigInsideBuiltinNonTopLevelFlow() throws IOException {
+    void shouldUpdateRealmCreateFlowAuthConfigInsideBuiltinSubFlow() throws IOException {
         doImport("6_update_realm__create_flow_auth_config_inside_builtin_non_top_level_flow.json");
 
         RealmRepresentation updatedRealm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
@@ -166,7 +166,7 @@ class ImportAuthenticatorConfigIT extends AbstractImportTest {
 
     @Test
     @Order(7)
-    void shouldUpdateRealmUpdateFlowAuthConfigInsideBuiltinNonTopLevelFlow() throws IOException {
+    void shouldUpdateRealmUpdateFlowAuthConfigInsideBuiltinSubFlow() throws IOException {
         doImport("7_update_realm__update_flow_auth_config_inside_builtin_non_top_level_flow.json");
 
         RealmRepresentation updatedRealm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
@@ -182,7 +182,7 @@ class ImportAuthenticatorConfigIT extends AbstractImportTest {
 
     @Test
     @Order(8)
-    void shouldUpdateRealmDeleteFlowAuthConfigInsideBuiltinNonTopLevelFlow() throws IOException {
+    void shouldUpdateRealmDeleteFlowAuthConfigInsideBuiltinSubFlow() throws IOException {
         doImport("8_update_realm__delete_flow_auth_config_inside_builtin_non_top_level_flow.json");
 
         RealmRepresentation updatedRealm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);

--- a/src/test/resources/import-files/auth-flows/63_update-realm__try-to-set-authenticator-basic-flow.json
+++ b/src/test/resources/import-files/auth-flows/63_update-realm__try-to-set-authenticator-basic-flow.json
@@ -1,0 +1,68 @@
+{
+  "enabled": true,
+  "realm": "realmWithFlow",
+  "authenticationFlows": [
+    {
+      "alias": "myCustomFlow",
+      "description": "myCustomFlow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-page-form",
+          "requirement": "ALTERNATIVE",
+          "priority": 32,
+          "flowAlias": "JToken Conditional",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "alias": "JToken Conditional",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorConfig": "review profile config 4",
+          "authenticator": "idp-review-profile",
+          "requirement": "REQUIRED",
+          "priority": 1,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "alias": "review profile config 4",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**: 

* Replace keycloak-config-cli naming nonTopLevelFlow with subFlow (Keycloak naming)
* Raise an exception, if authenticator is defined for a basic-flow

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

* fixes #558

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
