### PR TITLE
Support for managing `Client Scope Mappings` like other resources by configuring `import.managed.client-scope-mapping=<full|no-delete>`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Cookie Management for http client to support clustered environments with cookie based sticky sessions
 - Raise an exception, if authenticator is defined for a basic-flow execution
+- Support for managing `Client Scope Mappings` like other resources by configuring `import.managed.client-scope-mapping=<full|no-delete>`.
 
 ### Changes
 

--- a/docs/MANAGED.md
+++ b/docs/MANAGED.md
@@ -26,6 +26,7 @@ groups will be deleted. If you define `groups` but set an empty array, keycloak 
 | Required Actions          | You have to copy the default one to you import json.                             | `required-action`          |
 | Client Scopes             | -                                                                                | `client-scope`             |
 | Scope Mappings            | -                                                                                | `scope-mapping`            |
+| Client Scope Mappings     | -                                                                                | `client-scope-mapping`     |
 | Roles                     | -                                                                                | `role`                     |
 | Components                | You have to copy the default components to you import json.                      | `component`                |
 | Sub Components            | You have to copy the default components to you import json.                      | `sub-component`            |

--- a/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
+++ b/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
@@ -215,6 +215,9 @@ public class ImportConfigProperties {
         private final ImportManagedPropertiesValues scopeMapping;
 
         @NotNull
+        private final ImportManagedPropertiesValues clientScopeMapping;
+
+        @NotNull
         private final ImportManagedPropertiesValues component;
 
         @NotNull
@@ -238,6 +241,7 @@ public class ImportConfigProperties {
         public ImportManagedProperties(
                 ImportManagedPropertiesValues requiredAction, ImportManagedPropertiesValues group,
                 ImportManagedPropertiesValues clientScope, ImportManagedPropertiesValues scopeMapping,
+                ImportManagedPropertiesValues clientScopeMapping,
                 ImportManagedPropertiesValues component, ImportManagedPropertiesValues subComponent,
                 ImportManagedPropertiesValues authenticationFlow, ImportManagedPropertiesValues identityProvider,
                 ImportManagedPropertiesValues identityProviderMapper, ImportManagedPropertiesValues role,
@@ -246,6 +250,7 @@ public class ImportConfigProperties {
             this.group = group;
             this.clientScope = clientScope;
             this.scopeMapping = scopeMapping;
+            this.clientScopeMapping = clientScopeMapping;
             this.component = component;
             this.subComponent = subComponent;
             this.authenticationFlow = authenticationFlow;
@@ -265,6 +270,10 @@ public class ImportConfigProperties {
 
         public ImportManagedPropertiesValues getScopeMapping() {
             return scopeMapping;
+        }
+
+        public ImportManagedPropertiesValues getClientScopeMapping() {
+            return clientScopeMapping;
         }
 
         public ImportManagedPropertiesValues getComponent() {

--- a/src/main/java/de/adorsys/keycloak/config/service/ClientScopeMappingImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/ClientScopeMappingImportService.java
@@ -21,6 +21,7 @@
 package de.adorsys.keycloak.config.service;
 
 import de.adorsys.keycloak.config.model.RealmImport;
+import de.adorsys.keycloak.config.properties.ImportConfigProperties;
 import de.adorsys.keycloak.config.repository.ClientRepository;
 import de.adorsys.keycloak.config.repository.RealmRepository;
 import de.adorsys.keycloak.config.repository.RoleRepository;
@@ -48,15 +49,21 @@ public class ClientScopeMappingImportService {
     private final ClientRepository clientRepository;
     private final RoleRepository roleRepository;
     private final ScopeMappingRepository scopeMappingRepository;
+    private final ImportConfigProperties importConfigProperties;
 
     @Autowired
     public ClientScopeMappingImportService(
             RealmRepository realmRepository,
-            ClientRepository clientRepository, RoleRepository roleRepository, ScopeMappingRepository scopeMappingRepository) {
+            ClientRepository clientRepository,
+            RoleRepository roleRepository,
+            ScopeMappingRepository scopeMappingRepository,
+            ImportConfigProperties importConfigProperties
+    ) {
         this.realmRepository = realmRepository;
         this.clientRepository = clientRepository;
         this.roleRepository = roleRepository;
         this.scopeMappingRepository = scopeMappingRepository;
+        this.importConfigProperties = importConfigProperties;
     }
 
     public void doImport(RealmImport realmImport) {
@@ -71,7 +78,8 @@ public class ClientScopeMappingImportService {
             updateClientScopeMapping(realmName, scopeMappingToImport.getKey(), scopeMappingToImport.getValue(), existingClientScopeMappings);
         }
 
-        if (existingClientScopeMappings != null) {
+        if (existingClientScopeMappings != null && importConfigProperties.getManaged().getClientScopeMapping()
+                == ImportConfigProperties.ImportManagedProperties.ImportManagedPropertiesValues.FULL) {
             for (Map.Entry<String, List<ScopeMappingRepresentation>> existingClientScopeMapping : existingClientScopeMappings.entrySet()) {
                 removeClientScopeMapping(
                         realmName, existingClientScopeMapping.getKey(), existingClientScopeMapping.getValue(), clientScopeMappingsToImport

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,7 @@ import.managed.group=full
 import.managed.required-action=full
 import.managed.client-scope=full
 import.managed.scope-mapping=full
+import.managed.client-scope-mapping=full
 import.managed.component=full
 import.managed.sub-component=full
 import.managed.identity-provider=full

--- a/src/test/java/de/adorsys/keycloak/config/properties/ImportConfigPropertiesTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/properties/ImportConfigPropertiesTest.java
@@ -57,6 +57,7 @@ import static org.hamcrest.core.Is.is;
         "import.managed.required-action=no-delete",
         "import.managed.client-scope=no-delete",
         "import.managed.scope-mapping=no-delete",
+        "import.managed.client-scope-mapping=no-delete",
         "import.managed.component=no-delete",
         "import.managed.sub-component=no-delete",
         "import.managed.identity-provider=no-delete",
@@ -93,6 +94,7 @@ class ImportConfigPropertiesTest {
         assertThat(properties.getManaged().getRequiredAction(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getClientScope(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getScopeMapping(), is(ImportManagedPropertiesValues.NO_DELETE));
+        assertThat(properties.getManaged().getClientScopeMapping(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getComponent(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getSubComponent(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getIdentityProvider(), is(ImportManagedPropertiesValues.NO_DELETE));

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportManagedNoDeleteIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportManagedNoDeleteIT.java
@@ -29,6 +29,7 @@ import org.springframework.test.context.TestPropertySource;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,6 +41,7 @@ import static org.hamcrest.Matchers.hasSize;
         "import.managed.required-action=no-delete",
         "import.managed.client-scope=no-delete",
         "import.managed.scope-mapping=no-delete",
+        "import.managed.client-scope-mapping=no-delete",
         "import.managed.component=no-delete",
         "import.managed.sub-component=no-delete",
         "import.managed.identity-provider=no-delete",
@@ -102,6 +104,15 @@ class ImportManagedNoDeleteIT extends AbstractImportTest {
                 .filter((scopeMapping) -> scopeMapping.getClientScope().equals("offline_access"))
                 .collect(Collectors.toList());
         assertThat(createdScopeMappings, hasSize(1));
+
+        List<ScopeMappingRepresentation> createdClientScopeMappings = createdRealm.getClientScopeMappings()
+                .entrySet()
+                .stream()
+                .filter((clientScopeMappingEntry) -> clientScopeMappingEntry.getKey().equals("moped-client"))
+                .map((clientScopeMappingEntry) -> clientScopeMappingEntry.getValue())
+                .flatMap(scopeMappingRepresentations -> scopeMappingRepresentations.stream())
+                .collect(Collectors.toList());
+        assertThat(createdClientScopeMappings, hasSize(2));
 
         List<ComponentExportRepresentation> createdComponents = createdRealm.getComponents().get("org.keycloak.storage.UserStorageProvider")
                 .stream()

--- a/src/test/resources/import-files/managed-no-delete/0_create_realm.json
+++ b/src/test/resources/import-files/managed-no-delete/0_create_realm.json
@@ -116,6 +116,22 @@
       ]
     }
   ],
+  "clientScopeMappings": {
+    "moped-client": [
+      {
+        "client": "other-moped-client",
+        "roles": [
+          "moped-role"
+        ]
+      },
+      {
+        "clientScope": "my_clientScope",
+        "roles": [
+          "2nd-moped-role"
+        ]
+      }
+    ]
+  },
   "components": {
     "org.keycloak.keys.KeyProvider": [
       {
@@ -401,14 +417,14 @@
     "client": {
       "moped-client": [
         {
-          "name": "my_client_role",
+          "name": "moped-role",
           "description": "My moped-client role",
           "composite": false,
           "clientRole": true
         },
         {
-          "name": "my_other_client_role",
-          "description": "My other moped-client role",
+          "name": "2nd-moped-role",
+          "description": "My second moped-client role",
           "composite": false,
           "clientRole": true
         }

--- a/src/test/resources/import-files/managed-no-delete/1_update-realm_not-delete-one.json
+++ b/src/test/resources/import-files/managed-no-delete/1_update-realm_not-delete-one.json
@@ -55,6 +55,16 @@
       ]
     }
   ],
+  "clientScopeMappings": {
+    "moped-client": [
+      {
+        "clientScope": "my_clientScope",
+        "roles": [
+          "2nd-moped-role"
+        ]
+      }
+    ]
+  },
   "components": {
     "org.keycloak.keys.KeyProvider": [
       {

--- a/src/test/resources/import-files/managed-no-delete/2_update-realm_not-delete-all.json
+++ b/src/test/resources/import-files/managed-no-delete/2_update-realm_not-delete-all.json
@@ -6,6 +6,7 @@
   "requiredActions": [],
   "clientScopes": [],
   "scopeMappings": [],
+  "clientScopeMappings": {},
   "components": {},
   "identityProviders": [],
   "identityProviderMappers": [],


### PR DESCRIPTION
**What this PR does / why we need it**:
Support for managing `Client Scope Mappings` like other resources by configuring `import.managed.client-scope-mapping=<full|no-delete>`.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
