### PR TITLE
Fixed stale client level roles assignment 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Remove client level role assignment from a user, if all client's roles are removed from assigned in configuration.
+- Stale client level role assignment, if none roles of the client are left in configuration.
 
 ## [4.3.0] - 2021-09-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Use java 17 as default and use docker image `openjdk:17-slim`
 
+### Fixed
+
+- Remove client level role assignment from a user, if all client's roles are removed from assigned in configuration.
+
 ## [4.3.0] - 2021-09-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Stale client level role assignment, if none roles of the client are left in configuration.
+- Stale client level roles assignment, if all roles of the client are removed in configuration.
 
 ## [4.3.0] - 2021-09-28
 

--- a/src/main/java/de/adorsys/keycloak/config/repository/RoleRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/RoleRepository.java
@@ -262,17 +262,6 @@ public class RoleRepository {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    public List<String> getUserClientLevelRoles(String realmName, String username, String clientId) {
-        ClientRepresentation client = clientRepository.getByClientId(realmName, clientId);
-        UserResource userResource = userRepository.getResource(realmName, username);
-
-        List<RoleRepresentation> roles = userResource.roles()
-                .clientLevel(client.getId())
-                .listAll();
-
-        return roles.stream().map(RoleRepresentation::getName).collect(Collectors.toList());
-    }
-
     private List<String> toRoleNameList(@Nullable Collection<? extends RoleRepresentation> roles) {
         if (roles == null) {
             return Collections.emptyList();

--- a/src/test/java/de/adorsys/keycloak/config/test/util/KeycloakRepository.java
+++ b/src/test/java/de/adorsys/keycloak/config/test/util/KeycloakRepository.java
@@ -104,6 +104,27 @@ public class KeycloakRepository {
         return roles.stream().map(RoleRepresentation::getName).collect(Collectors.toList());
     }
 
+    public List<String> getServiceAccountUserClientLevelRoles(String realmName,
+                                                              String serviceAccountClientId,
+                                                              String clientId) {
+        UserRepresentation serviceAccount = keycloakProvider.getInstance().realm(realmName)
+                .clients().get(getClient(realmName, serviceAccountClientId).getId())
+                .getServiceAccountUser();
+        ClientRepresentation client = getClient(realmName, clientId);
+
+
+        UserResource userResource = keycloakProvider.getInstance()
+                .realm(realmName)
+                .users()
+                .get(serviceAccount.getId());
+
+        List<RoleRepresentation> roles = userResource.roles()
+                .clientLevel(client.getId())
+                .listEffective();
+
+        return roles.stream().map(RoleRepresentation::getName).collect(Collectors.toList());
+    }
+
     public boolean isClientRoleExisting(String realm, String clientId, String role) {
         ClientRepresentation client = getClient(realm, clientId);
 

--- a/src/test/resources/import-files/users/60.2_update_realm_remove_client_role_from_service_account.json
+++ b/src/test/resources/import-files/users/60.2_update_realm_remove_client_role_from_service_account.json
@@ -53,9 +53,7 @@
       "enabled": true,
       "clientAuthenticatorType": "client-secret",
       "secret": "my-special-client-secret",
-      "bearerOnly": true,
-      "redirectUris": [],
-      "webOrigins": []
+      "bearerOnly": true
     }
   ],
   "users": [
@@ -69,10 +67,6 @@
         "account": [
           "manage-account",
           "view-profile"
-        ],
-        "moped-client": [
-          "test_client_role",
-          "other_test_client_role"
         ]
       },
       "notBefore": 0


### PR DESCRIPTION
Hi, 
please consider this PR to fix the following issue:

**Which issue this PR fixes**
The pull request fixes the issue with stale client-level roles assignment on a user (service account) when a configuration JSON doesn't contain any roles of the client assigned on the user,

**Special notes for your reviewer**:
Please take a look at provided tests to reproduce the issue.

**PR Readiness Checklist**:
- the changelog was updated