### PR TITLE
Add a rule to ignore stale roles of Keycloak default clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Stale client level roles assignment, if all roles of the client are removed in configuration. The Keycloak default client roles (e.g. realm-management) will remain untouched though.
+- Stale client level roles assignment on a user, if the client is not present in the `clientRoles` JSON object in the config file.
+  The Keycloak default client roles (e.g. realm-management) will remain untouched though.
 
 
 ## [4.3.0] - 2021-09-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Stale client level roles assignment, if all roles of the client are removed in configuration.
+- Stale client level roles assignment, if all roles of the client are removed in configuration. The Keycloak default client roles (e.g. realm-management) will remain untouched though.
+
 
 ## [4.3.0] - 2021-09-28
 

--- a/src/main/java/de/adorsys/keycloak/config/service/UserImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/UserImportService.java
@@ -266,14 +266,15 @@ public class UserImportService {
                     .getUserClientLevelRoles(realmName, userToImport.getUsername());
 
             for (Map.Entry<String, List<String>> existing : existingClientsRoles.entrySet()) {
-                List<String> rolesToImport = clientRolesToImport.getOrDefault(existing.getKey(), Collections.emptyList());
+                List<String> rolesToImport = clientRolesToImport.get(existing.getKey());
 
-                if (rolesToImport.isEmpty()) {
+                if (rolesToImport == null) {
                     ClientRepresentation client = clientRepository.getByClientId(realmName, existing.getKey());
                     if (KeycloakUtil.isDefaultClient(client)) {
-                        // Do not remove keycloak default client's roles even if they are not in configuration
+                        // Do not remove keycloak default client's roles when they are not in the configuration
                         continue;
                     }
+                    rolesToImport = Collections.emptyList();
                 }
                 setupClientRoles(
                         existing.getKey(),

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportUsersIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportUsersIT.java
@@ -551,6 +551,11 @@ class ImportUsersIT extends AbstractImportTest {
                 REALM_NAME, client.getClientId(), "moped-client");
 
         assertThat(clientLevelRoles, containsInAnyOrder("test_client_role", "other_test_client_role"));
+
+        List<String> keycloakNativeClientLevelRoles = keycloakRepository.getServiceAccountUserClientLevelRoles(
+                REALM_NAME, client.getClientId(), "realm-management");
+
+        assertThat(keycloakNativeClientLevelRoles, contains("view-realm"));
     }
 
     @Test
@@ -577,6 +582,11 @@ class ImportUsersIT extends AbstractImportTest {
                 REALM_NAME, client.getClientId(), "moped-client");
 
         assertThat(clientLevelRoles, empty());
+
+        List<String> keycloakNativeClientLevelRoles = keycloakRepository.getServiceAccountUserClientLevelRoles(
+                REALM_NAME, client.getClientId(), "realm-management");
+
+        assertThat(keycloakNativeClientLevelRoles, contains("view-realm"));
     }
 
     private List<GroupRepresentation> getGroupsByUser(UserRepresentation user) {

--- a/src/test/resources/import-files/users/60.1_update_realm_add_clientl_with_service_account.json
+++ b/src/test/resources/import-files/users/60.1_update_realm_add_clientl_with_service_account.json
@@ -73,6 +73,9 @@
         "moped-client": [
           "test_client_role",
           "other_test_client_role"
+        ],
+        "realm-management": [
+          "view-realm"
         ]
       },
       "notBefore": 0

--- a/src/test/resources/import-files/users/60.3_update_realm_explicitly_remove_keycloak_client_role_from_service_account.json
+++ b/src/test/resources/import-files/users/60.3_update_realm_explicitly_remove_keycloak_client_role_from_service_account.json
@@ -1,0 +1,76 @@
+{
+  "enabled": true,
+  "realm": "realmWithUsers",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": true,
+  "roles": {
+    "client": {
+      "moped-client": [
+        {
+          "name": "test_client_role",
+          "description": "My moped-client role",
+          "composite": false,
+          "clientRole": true
+        },
+        {
+          "name": "other_test_client_role",
+          "description": "My changed other moped-client role",
+          "composite": false,
+          "clientRole": true
+        }
+      ]
+    }
+  },
+  "clients": [
+    {
+      "clientId": "technical-client",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "defaultClientScopes": [
+        "role_list",
+        "roles"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "clientId": "moped-client",
+      "name": "moped-client",
+      "description": "Moped-Client",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "my-special-client-secret",
+      "bearerOnly": true
+    }
+  ],
+  "users": [
+    {
+      "username": "service-account-technical-client",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "technical-client",
+      "clientRoles": {
+        "account": [
+          "manage-account",
+          "view-profile"
+        ],
+        "realm-management": []
+      },
+      "notBefore": 0
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR slightly softens the previous fix of the stale client-level roles, when the client is completely removed from the user's roles assignment. It just ignores the Keycloak default clients like `realm-management`, etc.

Admittedly the PR is a bit controversial, so it would be great to hear your opinion. But in our case, we have a mixed configuration done by the Keycloak admin console and with this tool.

**PR Readiness Checklist**:

- the changelog was updated accordingly. 
