### PR TITLE
Do not update resource if owner id is a username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- Workaround for creating client authorization resources, if a username is defined an owner through `owner.name`. Keycloak [excepts](https://github.com/keycloak/keycloak/blob/bfce612641a70e106b20b136431f0e4046b5c37f/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java#L2647-L2649) `owner.id` here instead `owner.name`.
+  See [#589](https://github.com/adorsys/keycloak-config-cli/pull/589)
+
 ## [4.4.0] - 2021-12-04
 
 ### Added

--- a/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
@@ -372,11 +372,26 @@ public class ClientImportService {
         ResourceRepresentation existingClientAuthorizationResource = existingClientAuthorizationResourcesMap
                 .get(authorizationResourceToImport.getName());
 
+        if (existingClientAuthorizationResource.getOwner().getId() == null && Objects.equals(existingClientAuthorizationResource.getOwner().getName(), authorizationResourceToImport.getOwner().getId())) {
+            existingClientAuthorizationResource.getOwner().setId(authorizationResourceToImport.getOwner().getId());
+            existingClientAuthorizationResource.getOwner().setName(null);
+        }
+
+        if (existingClientAuthorizationResource.getAttributes().isEmpty() && authorizationResourceToImport.getAttributes() == null) {
+            existingClientAuthorizationResource.setAttributes(null);
+        }
+
         boolean isEquals = CloneUtil.deepEquals(
                 authorizationResourceToImport, existingClientAuthorizationResource, "id", "_id"
         );
 
         if (isEquals) return;
+
+        // https://github.com/adorsys/keycloak-config-cli/issues/589
+        if (authorizationResourceToImport.getOwner().getId() == null && authorizationResourceToImport.getOwner().getName() != null) {
+            authorizationResourceToImport.getOwner().setId(authorizationResourceToImport.getOwner().getName());
+            authorizationResourceToImport.getOwner().setName(null);
+        }
 
         authorizationResourceToImport.setId(existingClientAuthorizationResource.getId());
         logger.debug("Update authorization resource '{}' for client '{}' in realm '{}'",

--- a/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
@@ -311,9 +311,7 @@ public class ClientImportService {
     ) {
         String[] ignoredProperties = new String[]{"policies", "resources", "permissions", "scopes"};
 
-        boolean isEquals = CloneUtil.deepEquals(
-                authorizationResourcesToImport, existingClientAuthorizationResources, ignoredProperties
-        );
+        boolean isEquals = CloneUtil.deepEquals(authorizationResourcesToImport, existingClientAuthorizationResources, ignoredProperties);
 
         if (isEquals) return;
 
@@ -336,9 +334,7 @@ public class ClientImportService {
                         .collect(Collectors.toMap(ResourceRepresentation::getName, resource -> resource));
 
         for (ResourceRepresentation authorizationResourceToImport : authorizationResourcesToImport) {
-            createOrUpdateAuthorizationResource(
-                    realmName, client, existingClientAuthorizationResourcesMap, authorizationResourceToImport
-            );
+            createOrUpdateAuthorizationResource(realmName, client, existingClientAuthorizationResourcesMap, authorizationResourceToImport);
         }
     }
 
@@ -349,18 +345,24 @@ public class ClientImportService {
             ResourceRepresentation authorizationResourceToImport
     ) {
         if (!existingClientAuthorizationResourcesMap.containsKey(authorizationResourceToImport.getName())) {
-            logger.debug("Create authorization resource '{}' for client '{}' in realm '{}'",
-                    authorizationResourceToImport.getName(), getClientIdentifier(client), realmName
-            );
-
-            clientRepository.createAuthorizationResource(
-                    realmName, client.getId(), authorizationResourceToImport
-            );
+            createAuthorizationResource(realmName, client, authorizationResourceToImport);
         } else {
-            updateAuthorizationResource(
-                    realmName, client, existingClientAuthorizationResourcesMap, authorizationResourceToImport
-            );
+            updateAuthorizationResource(realmName, client, existingClientAuthorizationResourcesMap, authorizationResourceToImport);
         }
+    }
+
+    private void createAuthorizationResource(
+            String realmName,
+            ClientRepresentation client,
+            ResourceRepresentation authorizationResourceToImport
+    ) {
+        // https://github.com/adorsys/keycloak-config-cli/issues/589
+        setAuthorizationResourceOwner(authorizationResourceToImport);
+
+        logger.debug("Create authorization resource '{}' for client '{}' in realm '{}'",
+                authorizationResourceToImport.getName(), getClientIdentifier(client), realmName);
+
+        clientRepository.createAuthorizationResource(realmName, client.getId(), authorizationResourceToImport);
     }
 
     private void updateAuthorizationResource(
@@ -372,7 +374,8 @@ public class ClientImportService {
         ResourceRepresentation existingClientAuthorizationResource = existingClientAuthorizationResourcesMap
                 .get(authorizationResourceToImport.getName());
 
-        if (existingClientAuthorizationResource.getOwner().getId() == null
+        if (existingClientAuthorizationResource.getOwner() != null
+                && existingClientAuthorizationResource.getOwner().getId() == null
                 && Objects.equals(existingClientAuthorizationResource.getOwner().getName(), authorizationResourceToImport.getOwner().getId())) {
             existingClientAuthorizationResource.getOwner().setId(authorizationResourceToImport.getOwner().getId());
             existingClientAuthorizationResource.getOwner().setName(null);
@@ -388,11 +391,7 @@ public class ClientImportService {
 
         if (isEquals) return;
 
-        // https://github.com/adorsys/keycloak-config-cli/issues/589
-        if (authorizationResourceToImport.getOwner().getId() == null && authorizationResourceToImport.getOwner().getName() != null) {
-            authorizationResourceToImport.getOwner().setId(authorizationResourceToImport.getOwner().getName());
-            authorizationResourceToImport.getOwner().setName(null);
-        }
+        setAuthorizationResourceOwner(authorizationResourceToImport);
 
         authorizationResourceToImport.setId(existingClientAuthorizationResource.getId());
         logger.debug("Update authorization resource '{}' for client '{}' in realm '{}'",
@@ -727,5 +726,13 @@ public class ClientImportService {
 
     private String getClientIdentifier(ClientRepresentation client) {
         return client.getClientId() != null ? client.getClientId() : client.getName();
+    }
+
+    // https://github.com/adorsys/keycloak-config-cli/issues/589
+    private void setAuthorizationResourceOwner(ResourceRepresentation representation) {
+        if (representation.getOwner() != null && representation.getOwner().getId() == null && representation.getOwner().getName() != null) {
+            representation.getOwner().setId(representation.getOwner().getName());
+            representation.getOwner().setName(null);
+        }
     }
 }

--- a/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
@@ -372,7 +372,8 @@ public class ClientImportService {
         ResourceRepresentation existingClientAuthorizationResource = existingClientAuthorizationResourcesMap
                 .get(authorizationResourceToImport.getName());
 
-        if (existingClientAuthorizationResource.getOwner().getId() == null && Objects.equals(existingClientAuthorizationResource.getOwner().getName(), authorizationResourceToImport.getOwner().getId())) {
+        if (existingClientAuthorizationResource.getOwner().getId() == null
+                && Objects.equals(existingClientAuthorizationResource.getOwner().getName(), authorizationResourceToImport.getOwner().getId())) {
             existingClientAuthorizationResource.getOwner().setId(authorizationResourceToImport.getOwner().getId());
             existingClientAuthorizationResource.getOwner().setName(null);
         }

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportClientsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportClientsIT.java
@@ -591,6 +591,7 @@ class ImportClientsIT extends AbstractImportTest {
         assertThat(authorizationSettingsResource.getUris(), containsInAnyOrder("/*"));
         assertThat(authorizationSettingsResource.getType(), is("http://servlet-authz/protected/resource"));
         assertThat(authorizationSettingsResource.getScopes(), containsInAnyOrder(new ScopeRepresentation("urn:servlet-authz:protected:resource:access")));
+        assertThat(authorizationSettingsResource.getOwner().getName(), is("service-account-auth-moped-client"));
 
         authorizationSettingsResource = getAuthorizationSettingsResource(authorizationSettingsResources, "Main Page");
         assertThat(authorizationSettingsResource.getUris(), empty());
@@ -726,6 +727,7 @@ class ImportClientsIT extends AbstractImportTest {
         assertThat(authorizationSettingsResource.getUris(), containsInAnyOrder("/*"));
         assertThat(authorizationSettingsResource.getType(), is("http://servlet-authz/protected/resource"));
         assertThat(authorizationSettingsResource.getScopes(), containsInAnyOrder(new ScopeRepresentation("urn:servlet-authz:protected:resource:access")));
+        assertThat(authorizationSettingsResource.getOwner().getName(), is("service-account-auth-moped-client"));
 
         authorizationSettingsResource = getAuthorizationSettingsResource(authorizationSettingsResources, "Premium Resource");
         assertThat(authorizationSettingsResource.getUris(), containsInAnyOrder("/protected/premium/*"));

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportClientsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportClientsIT.java
@@ -593,7 +593,7 @@ class ImportClientsIT extends AbstractImportTest {
         assertThat(authorizationSettingsResource.getScopes(), containsInAnyOrder(new ScopeRepresentation("urn:servlet-authz:protected:resource:access")));
         assertThat(authorizationSettingsResource.getOwner().getName(), is("service-account-auth-moped-client"));
         assertThat(authorizationSettingsResource.getAttributes(), aMapWithSize(1));
-        assertThat(authorizationSettingsResource.getAttributes(), hasEntry(is("key"), is("value")));
+        assertThat(authorizationSettingsResource.getAttributes(), hasEntry(is("key"), contains("value")));
 
         authorizationSettingsResource = getAuthorizationSettingsResource(authorizationSettingsResources, "Main Page");
         assertThat(authorizationSettingsResource.getUris(), empty());
@@ -662,8 +662,7 @@ class ImportClientsIT extends AbstractImportTest {
         assertThat(authorizationSettingsPolicy.getType(), is("resource"));
         assertThat(authorizationSettingsPolicy.getLogic(), is(Logic.POSITIVE));
         assertThat(authorizationSettingsPolicy.getDecisionStrategy(), is(DecisionStrategy.UNANIMOUS));
-        assertThat(authorizationSettingsPolicy.getConfig(), aMapWithSize(2));
-        assertThat(authorizationSettingsPolicy.getConfig(), hasEntry(equalTo("resources"), equalTo("[\"Protected Resource\"]")));
+        assertThat(authorizationSettingsPolicy.getConfig(), aMapWithSize(1));
         assertThat(authorizationSettingsPolicy.getConfig(), hasEntry(equalTo("applyPolicies"), equalTo("[\"All Users Policy\"]")));
 
         assertThat(authorizationSettings.getScopes(), hasSize(4));
@@ -731,8 +730,8 @@ class ImportClientsIT extends AbstractImportTest {
         assertThat(authorizationSettingsResource.getScopes(), containsInAnyOrder(new ScopeRepresentation("urn:servlet-authz:protected:resource:access")));
         assertThat(authorizationSettingsResource.getOwner().getName(), is("service-account-auth-moped-client"));
         assertThat(authorizationSettingsResource.getAttributes(), aMapWithSize(2));
-        assertThat(authorizationSettingsResource.getAttributes(), hasEntry(is("key"), is("value")));
-        assertThat(authorizationSettingsResource.getAttributes(), hasEntry(is("key2"), is("value2")));
+        assertThat(authorizationSettingsResource.getAttributes(), hasEntry(is("key"), contains("value")));
+        assertThat(authorizationSettingsResource.getAttributes(), hasEntry(is("key2"), contains("value2")));
 
 
         authorizationSettingsResource = getAuthorizationSettingsResource(authorizationSettingsResources, "Premium Resource");
@@ -825,8 +824,7 @@ class ImportClientsIT extends AbstractImportTest {
         assertThat(authorizationSettingsPolicy.getType(), is("resource"));
         assertThat(authorizationSettingsPolicy.getLogic(), is(Logic.POSITIVE));
         assertThat(authorizationSettingsPolicy.getDecisionStrategy(), is(DecisionStrategy.UNANIMOUS));
-        assertThat(authorizationSettingsPolicy.getConfig(), aMapWithSize(2));
-        assertThat(authorizationSettingsPolicy.getConfig(), hasEntry(equalTo("resources"), equalTo("[\"Protected Resource\"]")));
+        assertThat(authorizationSettingsPolicy.getConfig(), aMapWithSize(1));
         assertThat(authorizationSettingsPolicy.getConfig(), hasEntry(equalTo("applyPolicies"), equalTo("[\"All Users Policy\"]")));
 
         assertThat(authorizationSettings.getScopes(), hasSize(6));

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportClientsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportClientsIT.java
@@ -592,6 +592,8 @@ class ImportClientsIT extends AbstractImportTest {
         assertThat(authorizationSettingsResource.getType(), is("http://servlet-authz/protected/resource"));
         assertThat(authorizationSettingsResource.getScopes(), containsInAnyOrder(new ScopeRepresentation("urn:servlet-authz:protected:resource:access")));
         assertThat(authorizationSettingsResource.getOwner().getName(), is("service-account-auth-moped-client"));
+        assertThat(authorizationSettingsResource.getAttributes(), aMapWithSize(1));
+        assertThat(authorizationSettingsResource.getAttributes(), hasEntry(is("key"), is("value")));
 
         authorizationSettingsResource = getAuthorizationSettingsResource(authorizationSettingsResources, "Main Page");
         assertThat(authorizationSettingsResource.getUris(), empty());
@@ -728,6 +730,10 @@ class ImportClientsIT extends AbstractImportTest {
         assertThat(authorizationSettingsResource.getType(), is("http://servlet-authz/protected/resource"));
         assertThat(authorizationSettingsResource.getScopes(), containsInAnyOrder(new ScopeRepresentation("urn:servlet-authz:protected:resource:access")));
         assertThat(authorizationSettingsResource.getOwner().getName(), is("service-account-auth-moped-client"));
+        assertThat(authorizationSettingsResource.getAttributes(), aMapWithSize(2));
+        assertThat(authorizationSettingsResource.getAttributes(), hasEntry(is("key"), is("value")));
+        assertThat(authorizationSettingsResource.getAttributes(), hasEntry(is("key2"), is("value2")));
+
 
         authorizationSettingsResource = getAuthorizationSettingsResource(authorizationSettingsResources, "Premium Resource");
         assertThat(authorizationSettingsResource.getUris(), containsInAnyOrder("/protected/premium/*"));

--- a/src/test/resources/import-files/clients/11_update_realm__add_authorization.json
+++ b/src/test/resources/import-files/clients/11_update_realm__add_authorization.json
@@ -64,7 +64,9 @@
                 "name": "urn:servlet-authz:protected:resource:access"
               }
             ],
-            "attributes": {},
+            "attributes": {
+              "key": "value"
+            },
             "ownerManagedAccess": false
           },
           {

--- a/src/test/resources/import-files/clients/11_update_realm__add_authorization.json
+++ b/src/test/resources/import-files/clients/11_update_realm__add_authorization.json
@@ -56,6 +56,9 @@
               "/*"
             ],
             "type": "http://servlet-authz/protected/resource",
+            "owner": {
+              "name": "service-account-auth-moped-client"
+            },
             "scopes": [
               {
                 "name": "urn:servlet-authz:protected:resource:access"

--- a/src/test/resources/import-files/clients/11_update_realm__add_authorization.json
+++ b/src/test/resources/import-files/clients/11_update_realm__add_authorization.json
@@ -153,7 +153,7 @@
             "logic": "POSITIVE",
             "decisionStrategy": "UNANIMOUS",
             "config": {
-              "resources": "[\"Protected Resource\"]",
+              "resources": "[]",
               "applyPolicies": "[\"All Users Policy\"]"
             }
           }

--- a/src/test/resources/import-files/clients/12_update_realm__update_authorization.json
+++ b/src/test/resources/import-files/clients/12_update_realm__update_authorization.json
@@ -65,7 +65,10 @@
                 "name": "urn:servlet-authz:protected:resource:access"
               }
             ],
-            "attributes": {},
+            "attributes": {
+              "key": "value",
+              "key2": "value2"
+            },
             "ownerManagedAccess": false
           },
           {

--- a/src/test/resources/import-files/clients/12_update_realm__update_authorization.json
+++ b/src/test/resources/import-files/clients/12_update_realm__update_authorization.json
@@ -189,7 +189,7 @@
             "logic": "POSITIVE",
             "decisionStrategy": "UNANIMOUS",
             "config": {
-              "resources": "[\"Protected Resource\"]",
+              "resources": "[]",
               "applyPolicies": "[\"All Users Policy\"]"
             }
           }

--- a/src/test/resources/import-files/clients/12_update_realm__update_authorization.json
+++ b/src/test/resources/import-files/clients/12_update_realm__update_authorization.json
@@ -57,6 +57,9 @@
               "/*"
             ],
             "type": "http://servlet-authz/protected/resource",
+            "owner": {
+              "name": "service-account-auth-moped-client"
+            },
             "scopes": [
               {
                 "name": "urn:servlet-authz:protected:resource:access"


### PR DESCRIPTION
**What this PR does / why we need it**: on resources, keycloak excepts owner.id for username but return owner.name back

https://github.com/keycloak/keycloak/blob/bfce612641a70e106b20b136431f0e4046b5c37f/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java#L2647-L2649

This issue resolves (IMHO) an Keycloak bug.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #589 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
