### PR TITLE
Increase scope of apache commons library from `test` to `compile` again.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This dependency is needed by runtime (to be more specific by `keycloakImportProvider`) and thus needs to be included into the packaged JAR.

**What this PR does / why we need it**: This fixes #616 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
