### PR TITLE
GH-754 Auth-Flow in-use check now also considers Post-Broker login flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+We now also consider auth flows referenced by post-broker login flow Identity Provider configurations for flow in-use checks.
+
 ## [5.2.1] - 2022-06-20
 
 ### Added

--- a/src/test/resources/import-files/identity-providers/25_create_yet-another_identity-provider-with-custom-first-and-post-login-flow.json
+++ b/src/test/resources/import-files/identity-providers/25_create_yet-another_identity-provider-with-custom-first-and-post-login-flow.json
@@ -1,0 +1,55 @@
+{
+  "enabled": true,
+  "realm": "otherRealmWithIdentityProvidersTwoBrokerFlows",
+  "identityProviders": [
+    {
+      "alias": "saml-with-custom-idp-flows",
+      "providerId": "saml",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": true,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "my first login flow",
+      "postBrokerLoginFlowAlias": "my post login flow",
+      "config": {}
+    }
+  ],
+  "authenticationFlows": [
+    {
+      "alias": "my first login flow",
+      "description": "My auth first login for testing",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "requirement": "DISABLED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+
+    {
+      "alias": "my post login flow",
+      "description": "My auth post login for testing",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "requirement": "DISABLED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds missing check for used post-broker login flows to UsedAuthenticationFlowWorkaroundFactory.

Fixes https://github.com/adorsys/keycloak-config-cli/issues/754

Signed-off-by: Thomas Darimont [thomas.darimont@googlemail.com](mailto:thomas.darimont@googlemail.com)

[X] the CHANGELOG.md release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR