### PR TITLE
Add flags for delete behaviour of authz scopes and policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- Support for managing `Client Authorization Policies` like other resources by configuring `import.managed.client-authorization-policies=<full|no-delete>`. This prevents deletion of remote managed policies.
+- Support for managing `Client Authorization Scopes` like other resources by configuring `import.managed.client-authorization-scopes=<full|no-delete>`. This prevents deletion of remote managed scopes.
+
 ## [5.8.0] - 2023-07-14
 
 ### Added

--- a/docs/MANAGED.md
+++ b/docs/MANAGED.md
@@ -35,6 +35,8 @@ groups will be deleted. If you define `groups` but set an empty array, keycloak 
 | Identity Provider Mappers       | -                                                                                | `identity-provider-mapper`       |
 | Clients                         | -                                                                                | `client`                         |
 | Clients Authorization Resources | The 'Default Resource' is always included.                                       | `client-authorization-resources` |
+| Clients Authorization Policies  | -                                                                                | `client-authorization-policies`  |
+| Clients Authorization Scopes    | -                                                                                | `client-authorization-scopes`    |
 
 ## Disable deletion of managed entities
 

--- a/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
+++ b/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
@@ -150,13 +150,21 @@ public class ImportConfigProperties {
         @NotNull
         private final ImportManagedPropertiesValues clientAuthorizationResources;
 
+        @NotNull
+        private final ImportManagedPropertiesValues clientAuthorizationPolicies;
+
+        @NotNull
+        private final ImportManagedPropertiesValues clientAuthorizationScopes;
+
         public ImportManagedProperties(ImportManagedPropertiesValues requiredAction, ImportManagedPropertiesValues group,
                                        ImportManagedPropertiesValues clientScope, ImportManagedPropertiesValues scopeMapping,
                                        ImportManagedPropertiesValues clientScopeMapping, ImportManagedPropertiesValues component,
                                        ImportManagedPropertiesValues subComponent, ImportManagedPropertiesValues authenticationFlow,
                                        ImportManagedPropertiesValues identityProvider, ImportManagedPropertiesValues identityProviderMapper,
                                        ImportManagedPropertiesValues role, ImportManagedPropertiesValues client,
-                                       ImportManagedPropertiesValues clientAuthorizationResources) {
+                                       ImportManagedPropertiesValues clientAuthorizationResources,
+                                       ImportManagedPropertiesValues clientAuthorizationPolicies,
+                                       ImportManagedPropertiesValues clientAuthorizationScopes) {
             this.requiredAction = requiredAction;
             this.group = group;
             this.clientScope = clientScope;
@@ -170,6 +178,8 @@ public class ImportConfigProperties {
             this.role = role;
             this.client = client;
             this.clientAuthorizationResources = clientAuthorizationResources;
+            this.clientAuthorizationPolicies = clientAuthorizationPolicies;
+            this.clientAuthorizationScopes = clientAuthorizationScopes;
         }
 
         public ImportManagedPropertiesValues getRequiredAction() {
@@ -222,6 +232,14 @@ public class ImportConfigProperties {
 
         public ImportManagedPropertiesValues getClientAuthorizationResources() {
             return clientAuthorizationResources;
+        }
+
+        public ImportManagedPropertiesValues getClientAuthorizationPolicies() {
+            return clientAuthorizationPolicies;
+        }
+
+        public ImportManagedPropertiesValues getClientAuthorizationScopes() {
+            return clientAuthorizationScopes;
         }
 
         public enum ImportManagedPropertiesValues {

--- a/src/main/java/de/adorsys/keycloak/config/service/ClientAuthorizationImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/ClientAuthorizationImportService.java
@@ -153,8 +153,13 @@ public class ClientAuthorizationImportService {
             removeAuthorizationResources(realmName, client, existingAuthorization.getResources(), sanitizedAuthorizationResources);
         }
 
-        removeAuthorizationPolicies(realmName, client, existingAuthorization.getPolicies(), sanitizedAuthorizationPolicies);
-        removeAuthorizationScopes(realmName, client, existingAuthorization.getScopes(), authorizationSettingsToImport.getScopes());
+        if (importConfigProperties.getManaged().getClientAuthorizationPolicies() == FULL) {
+            removeAuthorizationPolicies(realmName, client, existingAuthorization.getPolicies(), sanitizedAuthorizationPolicies);
+        }
+
+        if (importConfigProperties.getManaged().getClientAuthorizationScopes() == FULL) {
+            removeAuthorizationScopes(realmName, client, existingAuthorization.getScopes(), authorizationSettingsToImport.getScopes());
+        }
 
         // refresh existingAuthorization
         existingAuthorization = clientRepository.getAuthorizationConfigById(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,6 +47,9 @@ import.managed.identity-provider-mapper=full
 import.managed.role=full
 import.managed.client=full
 import.managed.client-authorization-resources=full
+import.managed.client-authorization-policies=full
+import.managed.client-authorization-scopes=full
+
 logging.group.http=org.apache.http.wire
 logging.group.realm-config=de.adorsys.keycloak.config.provider.KeycloakImportProvider
 logging.group.keycloak-config-cli=de.adorsys.keycloak.config.service,de.adorsys.keycloak.config.KeycloakConfigRunner,de.adorsys.keycloak.config.provider.KeycloakProvider

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportManagedNoDeleteIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportManagedNoDeleteIT.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
 @TestPropertySource(properties = {
         "import.managed.authentication-flow=no-delete",
@@ -48,6 +49,8 @@ import static org.hamcrest.Matchers.hasSize;
         "import.managed.role=no-delete",
         "import.managed.client=no-delete",
         "import.managed.client-authorization-resources=no-delete",
+        "import.managed.client-authorization-policies=no-delete",
+        "import.managed.client-authorization-scopes=no-delete",
 })
 @SuppressWarnings({"java:S5961", "java:S5976"})
 class ImportManagedNoDeleteIT extends AbstractImportIT {
@@ -155,5 +158,23 @@ class ImportManagedNoDeleteIT extends AbstractImportIT {
                 .stream().filter(resource -> clientResourcesList.contains(resource.getName()))
                 .collect(Collectors.toList());
         assertThat(createdClientResourcesList, hasSize(2));
+
+        int createdScopesCount = createdRealm
+            .getClients()
+            .stream().filter(client -> Objects.equals(client.getName(), "moped-client")).findAny()
+            .orElseThrow(() -> new RuntimeException("Cannot find client 'moped-client'"))
+            .getAuthorizationSettings().getScopes()
+            .size();
+        assertThat(createdScopesCount, is(4));
+
+        long createdPoliciesCount = createdRealm
+            .getClients()
+            .stream().filter(client -> Objects.equals(client.getName(), "moped-client")).findAny()
+            .orElseThrow(() -> new RuntimeException("Cannot find client 'moped-client'"))
+            .getAuthorizationSettings().getPolicies().stream()
+            .filter(policy -> !policy.getName().equals("Default Policy"))
+            .filter(policy -> !policy.getName().equals("Default Permission"))
+            .count();
+        assertThat(createdPoliciesCount, is(1L));
     }
 }

--- a/src/test/resources/import-files/managed-no-delete/0_create_realm.json
+++ b/src/test/resources/import-files/managed-no-delete/0_create_realm.json
@@ -504,7 +504,18 @@
             ]
           }
         ],
-        "policies": [],
+        "policies": [
+          {
+            "name": "Policy A",
+            "description": "",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"moped-client\"]"
+            }
+          }
+        ],
         "scopes": [
           {
             "name": "urn:servlet-authz:protected:admin:access"


### PR DESCRIPTION
**What this PR does / why we need it**:

Remotly managed authz scopes and policies will be deleted if they are not defined in the realm-config. 
Especially (user related) policies need to be set up based on the existing users and their rights. The user policies will grow with growing user base. Users and their specific permissions should not be configured through the realm-config.

To prevent the tool to delete the existing policies and scopes I introduced 2 new config flags to select a **no-delete** mode (like it already exists for authz resources)

Which issue this PR fixes:
fixes #783 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR