### PR TITLE
Fix #907 (JSON logging broken)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- Fix issue [#907](/adorsys/keycloak-config-cli/issues/907):
+  - add missing dependency jakarta.xml.bind-api
+  - lower logstash version from 7.4 to 7.2: 7.2 is the last version to support logback 1.2, which is the version required for Spring and other components used here
 ## [5.8.0] - 2023-07-14
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <junit5-system-exit.version>1.1.2</junit5-system-exit.version>
         <keepachangelog.version>2.1.1</keepachangelog.version>
         <license-plugin.version>2.0.0</license-plugin.version>
-        <logstash-logback-encoder.version>7.4</logstash-logback-encoder.version>
+        <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
         <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
         <maven-replacer.version>1.5.3</maven-replacer.version>
@@ -89,6 +89,7 @@
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
         <jakarta.activation.version>2.1.2</jakarta.activation.version>
         <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
+        <jakarta.bind-api.version>4.0.0</jakarta.bind-api.version>
         <jakarta.mail.version>2.1.2</jakarta.mail.version>
         <spring-security-crypto.version>5.8.4</spring-security-crypto.version>
         <spotbugs-plugin.version>4.7.3.5</spotbugs-plugin.version>
@@ -253,6 +254,12 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <version>${jakarta.annotation.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakarta.bind-api.version}</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/de/adorsys/keycloak/config/jsonlog/JsonLogTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/jsonlog/JsonLogTest.java
@@ -1,0 +1,60 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2021 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.jsonlog;
+
+import de.adorsys.keycloak.config.extensions.GithubActionsExtension;
+import de.adorsys.keycloak.config.properties.ImportConfigProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+// From: https://tuhrig.de/testing-configurationproperties-in-spring-boot/
+@ExtendWith(SpringExtension.class)
+@ExtendWith(GithubActionsExtension.class)
+@SpringBootTest(classes = {JsonLogTest.TestConfiguration.class})
+@TestPropertySource(properties = {
+        "spring.main.log-startup-info=true",
+        "spring.profiles.active=json-log",
+        "import.files.locations=default",
+})
+class JsonLogTest {
+
+    @Autowired
+    ConfigurableApplicationContext applicationContext;
+
+    @Test
+    void startupUsingJsonLoggingShouldWork() {
+        assertThat(applicationContext.isActive(), is(true));
+    }
+
+    @EnableConfigurationProperties(ImportConfigProperties.class)
+    public static class TestConfiguration {
+        // nothing
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,6 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProfile name="! json-log">
+        <property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/spring.log}"/>
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+        <include resource="org/springframework/boot/logging/logback/file-appender.xml" />
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+            <appender-ref ref="FILE" />
+        </root>
+    </springProfile>
+
+    <springProfile name="json-log">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
+
     <logger name="org.springframework" level="ERROR"/>
     <logger name="de.adorsys.keycloak.config" level="DEBUG"/>
     <logger name="de.adorsys.keycloak.config.provider.KeycloakImportProvider" level="WARN"/>


### PR DESCRIPTION
fixes #907: add missing dependency jakarta.xml.bind-api; lower logstash version from 7.4 to 7.2 - 7.2 is the last version supporting logback 1.2, which is required by Spring and other components

