### PR TITLE
Add customField "app" to JSON log messages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -239,7 +239,7 @@ jobs:
             ${{ runner.os }}-pip-chart-testing-action
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (lint)
         run: ct lint --config contrib/charts/ct.yaml

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,7 +8,9 @@
 
     <springProfile name="json-log">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <customFields>{"app":"keycloak-config-cli"}</customFields>
+            </encoder>
         </appender>
     </springProfile>
 


### PR DESCRIPTION
Add the customField "app" with value "keycloak-config-cli" to each JSON log message. Fixes #942

**What this PR does / why we need it**:

In order to simplify finding logs from Keycloak Config CLI in a log aggregator like Kibana, it would be beneficial to mark every log entry with a custom field which identifies the CLI as its source.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #942 

