### PR TITLE
Fix: Client policies and profiles have to be imported before clients.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- The client policies in the configuration are applied during client import and configuration.
+
 ## [5.10.0] - 2023-12-12
 - Updated CI to use Keycloak 23.0.1
 - Added correct spelling of "authenticatorFlow" in all import files

--- a/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
@@ -195,13 +195,13 @@ public class RealmImportService {
     private void configureRealm(RealmImport realmImport, RealmRepresentation existingRealm) {
         clientScopeImportService.doImport(realmImport);
         clientScopeImportService.updateDefaultClientScopes(realmImport, existingRealm);
+        clientPoliciesImportService.doImport(realmImport);
         clientImportService.doImport(realmImport);
         roleImportService.doImport(realmImport);
         groupImportService.importGroups(realmImport);
         defaultGroupsImportService.doImport(realmImport);
         componentImportService.doImport(realmImport);
         userProfileImportService.doImport(realmImport);
-        clientPoliciesImportService.doImport(realmImport);
         userImportService.doImport(realmImport);
         requiredActionsImportService.doImport(realmImport);
         authenticationFlowsImportService.doImport(realmImport);


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR fixes the issue with the incorrect order of the imported realm resources

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #984

**Special notes for your reviewer**:

The PR is proposed with the assumption that it doesn't break the current behavior. Please let me know if the full case tests are required.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
