### PR TITLE
Update logback to 1.2.13 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <junit5-system-exit.version>1.1.2</junit5-system-exit.version>
         <keepachangelog.version>2.1.1</keepachangelog.version>
         <license-plugin.version>2.0.0</license-plugin.version>
+        <logback.version>1.2.13</logback.version>
         <logstash-logback-encoder.version>7.4</logstash-logback-encoder.version>
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
         <maven-release-plugin.version>3.0.1</maven-release-plugin.version>


### PR DESCRIPTION
**What this PR does / why we need it**: 
spring-boot-starter-logging:2.7.13 uses logback-classic:jar:1.2.12 and logback-core:jar:1.2.12 which are affected by CVE-2023-6378 and CVE-2023-6481. logback 1.2.13 contains the backport of this fix: https://github.com/qos-ch/logback/issues/745

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
