### PR TITLE
fix cli option name import.files.location -> import.files.locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- Corrected name of CLI option `--import.files.locations` in docs
+
 ## [5.10.0] - 2023-12-12
 - Updated CI to use Keycloak 23.0.1
 - Added correct spelling of "authenticatorFlow" in all import files

--- a/docs/IMPORT.md
+++ b/docs/IMPORT.md
@@ -1,6 +1,6 @@
 # Import settings
 
-The CLI option `--import.files.location` support multiple locations of files. In general, all resource location supported by Springs RessourceLoader and
+The CLI option `--import.files.locations` support multiple locations of files. In general, all resource location supported by Springs RessourceLoader and
 [PathMatchingResourcePatternResolver](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/io/support/PathMatchingResourcePatternResolver.html)
 are supported. This includes remote locations and zip files as well.
 


### PR DESCRIPTION
import.files.location -> import.files.locations

**What this PR does / why we need it**:
CLI option name is wrong in IMPORT.md. It is correct in e.g. README.md.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
