### PR TITLE
Revert "Fix docker hub link creation for releases"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -291,9 +291,6 @@ jobs:
           name: Release ${{ github.ref_name }}
           draft: false
           prerelease: ${{ contains(github.ref_name, 'rc') }}
-          run: |
-            TAG=${{ github.ref_name }}
-            echo "DOCKER_VERSION=${TAG#v}" >> $GITHUB_ENV
           files: |
             assets/keycloak-config-cli-*/keycloak-config-cli-*.jar
             assets/keycloak-config-cli-*/keycloak-config-cli-*.jar.sha256
@@ -304,7 +301,7 @@ jobs:
 
             ## DockerHub
 
-            * https://hub.docker.com/r/adorsys/keycloak-config-cli/tags?name=${DOCKER_VERSION}
+            * https://hub.docker.com/r/adorsys/keycloak-config-cli/tags?name=${{ github.ref_name }}
 
             ## Quay.io
 


### PR DESCRIPTION
Unfortunately the change didn't have the desired effect: https://github.com/adorsys/keycloak-config-cli/releases/tag/v6.0.0

Reverts adorsys/keycloak-config-cli#1007