### PR TITLE
Alias docker tags without Keycloak minor/patch version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,12 @@ jobs:
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3.0.0
 
+      - name: Compute SemVer parts of Keycloak version
+        id: keycloak_semver
+        uses: madhead/semver-utils@v3
+        with:
+          version: ${{ matrix.env.KEYCLOAK_VERSION }}
+
       - name: Set up Docker Build Metadata
         id: docker_meta
         uses: docker/metadata-action@v5.5.1
@@ -116,6 +122,9 @@ jobs:
             type=ref,event=pr
             type=semver,event=tag,pattern={{version}}
             type=raw,event=tag,value=latest,enable=${{ !contains(github.ref_name, 'rc') }}
+            # alias tags without Keycloak minor/patch version
+            type=semver,event=tag,pattern={{version}},suffix=-${{ steps.keycloak_semver.outputs.major }}
+            type=raw,event=tag,value=latest,enable=${{ !contains(github.ref_name, 'rc') }},suffix=-${{ steps.keycloak_semver.outputs.major }}
           labels: |
             maintainer=adorsys GmbH & Co. KG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- Alias docker tags without Keycloak minor/patch version
+
 ### Fixed
 - Importing more than 10 subgroups into a realm
 
@@ -52,9 +55,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed deprecated authenticator "registration-profile-action" from tests
 - Extended maven-replacer-plugin with breaking changes
 - Using util classes as replacement strategy for breaking changes (GroupUtil, SubGroupUtil)
-
-### Added
-- Alias docker tags without Keycloak minor/patch version
 
 ## [5.9.0] - 2023-10-13
 - Updated CI to use Keycloak 22.0.4


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the format of Docker tags is `<keycloak-config-cli version>`-`<keycloak library version>`, e.g. `6.0.2`-`22.0.4`. Since the Keycloak library is backwards compatible to within the same major version, usually the `keycloak-config-cli` user will want to use the latest minor/patch version of the Keycloak library, without having to manually update the image tag everytime there is a new release.

For each release, in addition to the existing Docker tags (`x.x.x`-`x.x.x`), the updated Actions workflow also tags the Docker image with the format `x.x.x`-`x` (e.g. `6.0.2`-`22`, `latest`-`22`).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #808

**Special notes for your reviewer**:

This was originally addressed in #850, but didn't work due to a typo. This PR contains the fix, as well as some improvements.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
