### PR TITLE
Fix docker hub tag in link for releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,7 +276,12 @@ jobs:
       - uses: actions/download-artifact@v4.1.7
         with:
           path: assets
-
+      - name: Write release tag without v
+        id: strip-v-tag
+        run: |
+          TAG=${GITHUB_REF_NAME#v}
+          echo Tag: $Tag
+          echo "::set-output name=tag::$TAG"
       - name: Create Release
         uses: softprops/action-gh-release@v2.0.6
         with:
@@ -293,7 +298,7 @@ jobs:
 
             ## DockerHub
 
-            * https://hub.docker.com/r/adorsys/keycloak-config-cli/tags?name=${{ github.ref_name }}
+            * https://hub.docker.com/r/adorsys/keycloak-config-cli/tags?name=${{ steps.strip-v-tag.outputs.tag }}
 
             ## Quay.io
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In the releases body, the link to the docker tags is broken because docker tags don't have a "v" prefix like the tags on github

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Test it if you want to merge now, I don't have the time to test it now and will do so in the couple next days if you want.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
