### PR TITLE
Use null-safe comparison in  AuthenticationExecutionExportRepresentationComparator

### DIFF
--- a/src/main/java/de/adorsys/keycloak/config/model/AuthenticationFlowImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/model/AuthenticationFlowImport.java
@@ -20,6 +20,7 @@
 
 package de.adorsys.keycloak.config.model;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.keycloak.representations.idm.AuthenticationExecutionExportRepresentation;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.springframework.stereotype.Component;
@@ -55,7 +56,7 @@ public class AuthenticationFlowImport extends AuthenticationFlowRepresentation {
                 AuthenticationExecutionExportRepresentation first,
                 AuthenticationExecutionExportRepresentation second
         ) {
-            return first.getPriority() - second.getPriority();
+            return ObjectUtils.compare(first.getPriority(), second.getPriority());
         }
     }
 }


### PR DESCRIPTION
cc @jonasvoelcker 

**What this PR does / why we need it**:

This avoids an InvalidImportException when parsing authenticationExecutions without priority.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #1071

**Special notes for your reviewer**:

There could be other places where we might also need to use a null-safe comparison.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [X] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR

IMHO no changelog entry needed as this ensures existing behaviour.
