### PR TITLE
Revert "Bump actions/upload-artifact from 4.3.1 to 4.3.3"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,7 +155,7 @@ jobs:
           cp target/keycloak-config-cli.jar keycloak-config-cli-${{ matrix.env.KEYCLOAK_VERSION }}.jar
           sha256sum keycloak-config-cli-${{ matrix.env.KEYCLOAK_VERSION }}.jar > keycloak-config-cli-${{ matrix.env.KEYCLOAK_VERSION }}.jar.sha256
 
-      - uses: actions/upload-artifact@v4.3.3
+      - uses: actions/upload-artifact@v4.3.1
         with:
           name: keycloak-config-cli-${{ matrix.env.KEYCLOAK_VERSION }}
           if-no-files-found: error


### PR DESCRIPTION
Reverts adorsys/keycloak-config-cli#1030