### PR TITLE
Fix securityContext settings in job template

### DIFF
--- a/contrib/charts/keycloak-config-cli/templates/job.yaml
+++ b/contrib/charts/keycloak-config-cli/templates/job.yaml
@@ -34,7 +34,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.resources }}
           resources:
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
             {{- range $name, $value := .Values.env }}
@@ -55,9 +55,9 @@ spec:
                   name: "{{ tpl .Values.existingSecret . }}"
                   key: "{{ .Values.existingSecretKey }}"
           {{- end }}
-          {{- with .Values.securityContext }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: config
@@ -83,4 +83,4 @@ spec:
       {{- with .Values.securityContext }}
       securityContext:
       {{- toYaml . | nindent 8 }}
-  {{- end }}
+      {{- end }}


### PR DESCRIPTION
Intends needed to be fixed and containerSecurityContext value settings are used

**What this PR does / why we need it**:

When I want to use the options: 
```
securityContext:
  runAsGroup: 65534
  runAsNonRoot: true
  runAsUser: 65534
  seccompProfile:
    type: RuntimeDefault
containerSecurityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
    - ALL
    - CAP_NET_RAW
```
the entries will not be set correctly in the resulting manifest

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
