### PR TITLE
Revert "Bump docker/build-push-action from 5.4.0 to 6.5.0"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,7 +136,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.4.0
 
       - name: Build and push
-        uses: docker/build-push-action@v6.5.0
+        uses: docker/build-push-action@v5.4.0
         with:
           build-args: |-
             KEYCLOAK_VERSION=${{ matrix.env.KEYCLOAK_VERSION }}


### PR DESCRIPTION
This reverts commit b488ce782b405c780b4efb5fc9748077c0c55521.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
