### PR TITLE
Bump com.fasterxml.jackson:jackson-bom from 2.17.1 to 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <commons-text.version>1.12.0</commons-text.version>
         <failsafe.version>3.3.2</failsafe.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
-        <jackson.version>2.17.1</jackson.version>
+        <jackson.version>2.17.2</jackson.version>
         <jacoco.version>0.8.12</jacoco.version>
         <junit-pioneer.version>2.2.0</junit-pioneer.version>
         <keepachangelog.version>2.1.1</keepachangelog.version>


### PR DESCRIPTION
**What this PR does / why we need it**:

improvement from https://github.com/adorsys/keycloak-config-cli/pull/1124. Binary 2.17.2.redhat-00001 renamed to 2.17.2 in repository.
