### PR TITLE
Fix env.JAVA_HOME test failures before build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix env.JAVA_HOME test failures by ensuring env is set before build
+
+## [6.1.10] - 2024-10-04
 - Added support for User Profile Setting: `unmanagedAttributePolicy`
 
 ### Fixed

--- a/mvnw
+++ b/mvnw
@@ -130,6 +130,7 @@ fi
 
 if [ -z "$JAVA_HOME" ] ; then
   echo "Warning: JAVA_HOME environment variable is not set."
+  exit 1
 fi
 
 # traverses directory structure from process work directory to filesystem root

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.4.1</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${maven-release-plugin.version}</version>
                 </plugin>
@@ -372,6 +377,27 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-java-home</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireEnvironmentVariable>
+                                    <variableName>JAVA_HOME</variableName>
+                                    <message>JAVA_HOME environment variable must be set!</message>
+                                </requireEnvironmentVariable>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
**What this PR does / why we need it**: update The Maven Wrapper script (mvnw) and potential build with mvn now incorporate a verification step to ensure the presence of the JAVA_HOME environment variable before executing any Maven commands. This enhancement mitigates potential build failures stemming from the absence of a configured JAVA_HOME environment variable.

**Which issue this PR fixes**:  fixes https://github.com/adorsys/keycloak-config-cli/issues/1149

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
