### PR TITLE
Fix enabling a realm clears the value of eventsExpiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix enabling a realm clears the value of eventsExpiration
+
+## [6.1.10] - 2024-10-14
+
 - Added support for User Profile Setting: `unmanagedAttributePolicy`
 
 ### Fixed

--- a/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
@@ -187,8 +187,11 @@ public class RealmImportService {
 
         RealmRepresentation realm = CloneUtil.deepClone(realmImport, RealmRepresentation.class, ignoredPropertiesForRealmImport);
 
-        // The state must be loaded before we update realm to prevent
-        // the state erasure by custom attributes from configuration
+        RealmRepresentation existingRealm = realmRepository.get(realmImport.getRealm());
+
+        if (existingRealm.getEventsExpiration() != null) {
+            realm.setEventsExpiration(existingRealm.getEventsExpiration());
+        }
         stateService.loadState(realm);
 
         realmRepository.update(realm);

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportSimpleRealmIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportSimpleRealmIT.java
@@ -302,4 +302,17 @@ class ImportSimpleRealmIT extends AbstractImportIT {
 
         assertThat(thrown.getMessage(), matchesPattern("(?s)^Unable to parse file 'file:.+/import-files/simple-realm/81_invalid_json.json': while parsing a flow mapping.+"));
     }
+    @Test
+    @Order(83)
+    void shouldPreserveEventsExpirationWhenUpdatingRealm() throws Exception {
+        doImport("08.3_update_simple-realm_with_events-expiration.json");
+
+        RealmRepresentation realm = keycloakProvider.getInstance().realm(REALM_NAME).toRepresentation();
+        assertThat(realm.getEventsExpiration(), is(3600L));
+
+        doImport("08.4_update_simple-realm_without_events-expiration.json");
+
+        realm = keycloakProvider.getInstance().realm(REALM_NAME).toRepresentation();
+        assertThat(realm.getEventsExpiration(), is(3600L));
+    }
 }

--- a/src/test/resources/import-files/simple-realm/08.3_update_simple-realm_with_events-expiration.json
+++ b/src/test/resources/import-files/simple-realm/08.3_update_simple-realm_with_events-expiration.json
@@ -1,0 +1,5 @@
+{
+  "realm": "simple",
+  "eventsEnabled": true,
+  "eventsExpiration": 3600
+}

--- a/src/test/resources/import-files/simple-realm/08.4_update_simple-realm_without_events-expiration.json
+++ b/src/test/resources/import-files/simple-realm/08.4_update_simple-realm_without_events-expiration.json
@@ -1,0 +1,4 @@
+{
+  "realm": "simple",
+  "eventsEnabled": true
+}


### PR DESCRIPTION
**What this PR does / why we need it**: When a realm is enabled using an isolated configuration file, the eventsExpiration value is cleared, which is not the expected behavior:

**Which issue this PR fixes** :  fixes https://github.com/adorsys/keycloak-config-cli/issues/1018

**Special notes for your reviewer**: 
The eventsExpiration value should remain unaffected when importing configurations, even if they are split into multiple files.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
