### PR TITLE
Adds support for default first broker login flow on realm level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Support for first broker login flows defined on realm level
+
 ### Fixed
 
 - Allow executions of same provider with different configurations in Sub-Auth-Flows

--- a/src/main/java/de/adorsys/keycloak/config/factory/UsedAuthenticationFlowWorkaroundFactory.java
+++ b/src/main/java/de/adorsys/keycloak/config/factory/UsedAuthenticationFlowWorkaroundFactory.java
@@ -75,6 +75,7 @@ public class UsedAuthenticationFlowWorkaroundFactory {
         private String dockerAuthenticationFlow;
         private String registrationFlow;
         private String resetCredentialsFlow;
+        private String firstBrokerLoginFlow;
 
         private UsedAuthenticationFlowWorkaround(RealmImport realmImport) {
             this.realmImport = realmImport;
@@ -168,6 +169,13 @@ public class UsedAuthenticationFlowWorkaroundFactory {
                     }
                 }
             }
+            if (Objects.equals(existingRealm.getFirstBrokerLoginFlow(), topLevelFlowAlias)) {
+                logger.debug(
+                        "Temporary disable first-broker-login-flow for in realm '{}' which is '{}'",
+                        realmImport.getRealm(), topLevelFlowAlias
+                );
+                disableFirstBrokerLoginFlow(existingRealm);
+            }
         }
 
         private void disablePostBrokerLoginFlowsIfNeeded(String topLevelFlowAlias, RealmRepresentation existingRealm) {
@@ -238,6 +246,15 @@ public class UsedAuthenticationFlowWorkaroundFactory {
             resetCredentialsFlow = existingRealm.getResetCredentialsFlow();
 
             existingRealm.setResetCredentialsFlow(otherFlowAlias);
+            realmRepository.update(existingRealm);
+        }
+
+        private void disableFirstBrokerLoginFlow(RealmRepresentation existingRealm) {
+            String otherFlowAlias = searchTemporaryCreatedTopLevelFlowForReplacement();
+
+            firstBrokerLoginFlow = existingRealm.getFirstBrokerLoginFlow();
+
+            existingRealm.setFirstBrokerLoginFlow(otherFlowAlias);
             realmRepository.update(existingRealm);
         }
 
@@ -323,7 +340,8 @@ public class UsedAuthenticationFlowWorkaroundFactory {
                     || Strings.isNotBlank(registrationFlow)
                     || Strings.isNotBlank(resetCredentialsFlow)
                     || !resetFirstBrokerLoginFlow.isEmpty()
-                    || !resetPostBrokerLoginFlow.isEmpty();
+                    || !resetPostBrokerLoginFlow.isEmpty()
+                    || Strings.isNotBlank(firstBrokerLoginFlow);
         }
 
         private void resetFlows(RealmRepresentation existingRealm) {
@@ -415,6 +433,14 @@ public class UsedAuthenticationFlowWorkaroundFactory {
 
                 identityProviderRepresentation.setFirstBrokerLoginFlowAlias(entry.getValue());
                 identityProviderRepository.update(existingRealm.getRealm(), identityProviderRepresentation);
+            }
+            if (Strings.isNotBlank(firstBrokerLoginFlow)) {
+                logger.debug(
+                        "Reset first-broker-login-flow in realm '{}' to '{}'",
+                        realmImport.getRealm(), firstBrokerLoginFlow
+                );
+
+                existingRealm.setFirstBrokerLoginFlow(firstBrokerLoginFlow);
             }
         }
 

--- a/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
@@ -110,6 +110,7 @@ public class AuthenticationFlowsImportService {
         realm.setDockerAuthenticationFlow(realmImport.getDockerAuthenticationFlow());
         realm.setRegistrationFlow(realmImport.getRegistrationFlow());
         realm.setResetCredentialsFlow(realmImport.getResetCredentialsFlow());
+        realm.setFirstBrokerLoginFlow(realmImport.getFirstBrokerLoginFlow());
 
         realmRepository.update(realm);
     }

--- a/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
@@ -59,6 +59,7 @@ public class RealmImportService {
             "defaultOptionalClientScopes",
             "clientProfiles",
             "clientPolicies",
+            "firstBrokerLoginFlow",
     };
 
     private static final Logger logger = LoggerFactory.getLogger(RealmImportService.class);

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
@@ -45,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings({"java:S5961", "java:S5976", "deprecation"})
 class ImportAuthenticationFlowsIT extends AbstractImportIT {
     private static final String REALM_NAME = "realmWithFlow";
+    private static final String DEFAULT_FLOW_REALM_NAME = "realmWithDefaultFlow";
 
     ImportAuthenticationFlowsIT() {
         this.resourcePath = "import-files/auth-flows";
@@ -1208,6 +1209,31 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(realm.isEnabled(), is(true));
 
         assertThat(flow.getAuthenticationExecutions().get(1).getRequirement(), is("DISABLED"));
+    }
+
+    @Test
+    void shouldSetCustomFirstBrokerLoginFlowAsDefaultFlow() throws IOException {
+        doImport("init_custom_default_first-broker-login-flow.json");
+
+        RealmRepresentation realm = keycloakProvider.getInstance().realm(DEFAULT_FLOW_REALM_NAME).partialExport(true, true);
+
+        assertThat(realm.getRealm(), is(DEFAULT_FLOW_REALM_NAME));
+        assertThat(realm.isEnabled(), is(true));
+        assertThat(realm.getFirstBrokerLoginFlow(), is("my auth flow"));
+    }
+
+    @Test
+    void shouldUpdateCustomFirstBrokerLoginFlowWhenSetAsDefault() throws IOException {
+        doImport("init_custom_default_first-broker-login-flow.json");
+        doImport("updated_custom_default_first-broker-login-flow.json");
+
+        RealmRepresentation realm = keycloakProvider.getInstance().realm(DEFAULT_FLOW_REALM_NAME).partialExport(true, true);
+        AuthenticationFlowRepresentation flow = getAuthenticationFlow(realm, "my auth flow");
+
+        assertThat(realm.getRealm(), is(DEFAULT_FLOW_REALM_NAME));
+        assertThat(realm.isEnabled(), is(true));
+        assertThat(realm.getFirstBrokerLoginFlow(), is("my auth flow"));
+        assertThat(flow.getAuthenticationExecutions().getFirst().getAuthenticator(), is("idp-auto-link"));
     }
 
     private List<AuthenticationExecutionExportRepresentation> getExecutionFromFlow(AuthenticationFlowRepresentation flow, String executionAuthenticator) {

--- a/src/test/resources/import-files/auth-flows/init_custom_default_first-broker-login-flow.json
+++ b/src/test/resources/import-files/auth-flows/init_custom_default_first-broker-login-flow.json
@@ -1,0 +1,24 @@
+{
+  "enabled": true,
+  "realm": "realmWithDefaultFlow",
+  "firstBrokerLoginFlow": "my auth flow",
+  "authenticationFlows": [
+    {
+      "alias": "my auth flow",
+      "description": "My auth flow for testing",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": true,
+          "autheticatorFlow": false,
+          "authenticatorFlow": false
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/import-files/auth-flows/updated_custom_default_first-broker-login-flow.json
+++ b/src/test/resources/import-files/auth-flows/updated_custom_default_first-broker-login-flow.json
@@ -1,0 +1,24 @@
+{
+  "enabled": true,
+  "realm": "realmWithDefaultFlow",
+  "firstBrokerLoginFlow": "my auth flow",
+  "authenticationFlows": [
+    {
+      "alias": "my auth flow",
+      "description": "My auth flow for testing",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-auto-link",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false,
+          "authenticatorFlow": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for a custom default first broker login flow defined on realm level:

```yaml
realm: myRealm
firstBrokerLoginFlow: 'my-first-broker-login'
# ...

authenticationFlows:
- alias: my-first-broker-login
        providerId: basic-flow
        topLevel: true
        builtIn: false
        authenticationExecutions:
          - authenticatorFlow: true
            requirement: REQUIRED
            priority: 20
            autheticatorFlow: true
            flowAlias: my-first-broker-login User creation or linking
            userSetupAllowed: false
# ...
```

Without these changes the CLI was not able to import/update the firstBrokerLoginFlow because it was missing the special treatment like `browserFlow` or `registrationFlow`.

**Special notes for your reviewer**:

Have a nice day 🙂 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
