### PR TITLE
allow environment variables from existing secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Fixed
+- Allow environment variables from existing secrets [#822](https://github.com/adorsys/keycloak-config-cli/issues/822)
+### Fixed
 - Fix  versioning in artifact to contain the correct keycloak version [#1097](https://github.com/adorsys/keycloak-config-cli/issues/1097)
 
 ### Fixed

--- a/contrib/charts/keycloak-config-cli/Chart.yaml
+++ b/contrib/charts/keycloak-config-cli/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: keycloak-config-cli
 description: Import JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
 home: https://github.com/adorsys/keycloak-config-cli
-version: 6.1.7-SNAPSHOT
-appVersion: 6.1.7-SNAPSHOT
+version: 4.0.1
+appVersion: 4.0.1
 maintainers:
   - name: jkroepke
     email: joe@adorsys.de

--- a/contrib/charts/keycloak-config-cli/Chart.yaml
+++ b/contrib/charts/keycloak-config-cli/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: keycloak-config-cli
 description: Import JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
 home: https://github.com/adorsys/keycloak-config-cli
-version: 4.0.1
-appVersion: 4.0.1
+version: 6.1.7-SNAPSHOT
+appVersion: 6.1.7-SNAPSHOT
 maintainers:
   - name: jkroepke
     email: joe@adorsys.de

--- a/contrib/charts/keycloak-config-cli/templates/job.yaml
+++ b/contrib/charts/keycloak-config-cli/templates/job.yaml
@@ -54,7 +54,16 @@ spec:
                 secretKeyRef:
                   name: "{{ tpl .Values.existingSecret . }}"
                   key: "{{ .Values.existingSecretKey }}"
-          {{- end }}
+            {{- end }}
+            {{- if .Values.existingSecrets }}
+            {{- range .Values.existingSecrets }}
+            - name: {{ .envVar }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
+            {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext:
           {{- toYaml . | nindent 12 }}

--- a/contrib/charts/keycloak-config-cli/values.yaml
+++ b/contrib/charts/keycloak-config-cli/values.yaml
@@ -55,6 +55,11 @@ podLabels: {}
 
 ## Extra Annotations to be added to pod
 podAnnotations: {}
+# New section for existing secrets
+existingSecrets:
+# - name: my-existing-secret
+#   key: my-secret-key
+#   envVar: MY_ENV_VAR
 
 config: {}
   # <realm name>:


### PR DESCRIPTION
**What this PR does / why we need it**:  Helm chart to Allow environment variables from existing secrets

**Which issue this PR fixes** : **https://github.com/adorsys/keycloak-config-cli/issues/822**

**Special notes for your reviewer**:  

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
