### PR TITLE
Fix required action import handling for no-delete option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Fixed
+- Fix required action import handling for no-delete option [#834](https://github.com/adorsys/keycloak-config-cli/issues/834)
+
+### Fixed
 - Allow environment variables from existing secrets [#822](https://github.com/adorsys/keycloak-config-cli/issues/822)
 ### Fixed
 - Fix  versioning in artifact to contain the correct keycloak version [#1097](https://github.com/adorsys/keycloak-config-cli/issues/1097)

--- a/src/main/java/de/adorsys/keycloak/config/service/RequiredActionsImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RequiredActionsImportService.java
@@ -63,7 +63,7 @@ public class RequiredActionsImportService {
 
         List<RequiredActionProviderRepresentation> existingRequiredActions = requiredActionRepository.getAll(realmName);
 
-        if (importConfigProperties.getManaged().getClientScope() == ImportManagedPropertiesValues.FULL) {
+        if (importConfigProperties.getManaged().getRequiredAction() == ImportManagedPropertiesValues.FULL) {
             deleteRequiredActionsMissingInImport(realmName, requiredActions, existingRequiredActions);
         }
 


### PR DESCRIPTION
**What this PR does / why we need it**: This PR ensures correct configuration handling for required actions. This change resolves an issue where deletion of required actions wasn't properly controlled by the `--import.managed.required-action=no-delete` CLI option.

**Which issue this PR fixes** *(https://github.com/adorsys/keycloak-config-cli/issues/834)

**Special notes for your reviewer**: 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
