### PR TITLE
Fix ci failure actions/upload-artifact@v4 new public artifacts are no longer accessible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -301,6 +301,7 @@ jobs:
       - uses: actions/download-artifact@v4.1.8
         with:
           path: assets
+          pattern: keycloak-config-cli*
       - name: Write release tag without v
         id: strip-v-tag
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Fix ci failure actions/upload-artifact@v4 new public artifacts are no longer accessible
 ## [6.2.0] - 2024-12-03
 ### Fix Fails to delete authentication flow when it's referenced as an IdP [#868](https://github.com/adorsys/keycloak-config-cli/issues/868)
 -


### PR DESCRIPTION
**What this PR does / why we need it**: Fix ci failure actions/upload-artifact@v4 new public artifacts are no longer accessible

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
