### PR TITLE
fix: Deleting protocol mappers during config import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix to manage Remote state import for clientscopes and scopeMappings [#1012](https://github.com/adorsys/keycloak-config-cli/issues/1012)
 
 ### Fixed
-- Fixed to delete protocol mappers if not in the import
+- Fixed to delete protocol mappers if not in the import[#746](https://github.com/orgs/adorsys/projects/5/views/1?pane=issue&itemId=80856370&issue=adorsys%7Ckeycloak-config-cli%7C746)
 
 ### Fixed
 - Allow environment variables from existing secrets [#822](https://github.com/adorsys/keycloak-config-cli/issues/822)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix to manage Remote state import for clientscopes and scopeMappings [#1012](https://github.com/adorsys/keycloak-config-cli/issues/1012)
 
 ### Fixed
+- Fixed to delete protocol mappers if not in the import
+
+### Fixed
 - Allow environment variables from existing secrets [#822](https://github.com/adorsys/keycloak-config-cli/issues/822)
 
 ### Fixed

--- a/src/main/java/de/adorsys/keycloak/config/util/ProtocolMapperUtil.java
+++ b/src/main/java/de/adorsys/keycloak/config/util/ProtocolMapperUtil.java
@@ -22,10 +22,8 @@ package de.adorsys.keycloak.config.util;
 
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class ProtocolMapperUtil {
     private ProtocolMapperUtil() {
@@ -35,23 +33,19 @@ public class ProtocolMapperUtil {
             List<ProtocolMapperRepresentation> protocolMappers,
             List<ProtocolMapperRepresentation> existingProtocolMappers
     ) {
-        List<ProtocolMapperRepresentation> protocolMappersToRemove = new ArrayList<>();
-
-        if (existingProtocolMappers == null) {
-            return protocolMappersToRemove;
+        if (existingProtocolMappers == null || existingProtocolMappers.isEmpty()) {
+            return List.of(); // Return an immutable empty list
         }
 
-        for (ProtocolMapperRepresentation existingProtocolMapper : existingProtocolMappers) {
-            boolean shouldRemove = protocolMappers.stream().noneMatch(
-                    m -> Objects.equals(m.getName(), existingProtocolMapper.getName())
-            );
+        Set<String> protocolMapperNames = Optional.ofNullable(protocolMappers)
+                .stream()
+                .flatMap(List::stream)
+                .map(ProtocolMapperRepresentation::getName)
+                .collect(Collectors.toSet());
 
-            if (shouldRemove) {
-                protocolMappersToRemove.add(existingProtocolMapper);
-            }
-        }
-
-        return protocolMappersToRemove;
+        return existingProtocolMappers.stream()
+                .filter(existingMapper -> !protocolMapperNames.contains(existingMapper.getName()))
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     public static List<ProtocolMapperRepresentation> estimateProtocolMappersToAdd(


### PR DESCRIPTION
**What this PR does / why we need it**: To be able to delete protocol mappers

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #746

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [X] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
