### PR TITLE
 added migration guide for keycloak 25.0.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,7 +251,7 @@ jobs:
         run: ./mvnw ${MAVEN_CLI_OPTS} -Dkeycloak.version=${{ matrix.env.KEYCLOAK_VERSION }} -Dkeycloak.client.version=${{ matrix.env.KEYCLOAK_CLIENT_VERSION }} -Dkeycloak.dockerTagSuffix="-legacy" ${ADJUSTED_RESTEASY_VERSION} clean verify ${COMPATIBILITY_PROFILE}
 
   lint-other-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- added migration guide for keycloak 25.0.1 [#1072](https://github.com/adorsys/keycloak-config-cli/issues/1072)
 ### Added
 - Publish charts with github pages [#941](https://github.com/adorsys/keycloak-config-cli/issues/941)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -223,3 +223,89 @@ The example above should therefore be rewritten as:
   ]
 }
 ```
+# Migration Guide
+
+### Keycloak Version 25.0.1
+
+#### Basic Scope Handling
+
+With the introduction of the dedicated "basic" scope in Keycloak, existing realm configurations with custom clients might not contain the `sub` claim anymore. This is because the new `basic` scope that emits those claims might be removed by an explicit `defaultClientScopes` configuration.
+
+A workaround is to configure the `basic` scope explicitly via `defaultClientScopes`:
+```yaml
+defaultClientScopes:
+  - "basic"
+```
+Ensure that your client configurations include the basic scope to maintain the presence of the sub claim in access tokens.
+
+#### Example Client Configuration
+Here is an example of a previously working client definition, which will produce access tokens with the sub claim.
+```yaml
+  - clientId: app-greetme
+    protocol: openid-connect
+    name: Acme Greet Me
+    description: "App Greet Me Description"
+    enabled: true
+    publicClient: true
+    standardFlowEnabled: true
+    directAccessGrantsEnabled: false
+    alwaysDisplayInConsole: true
+    serviceAccountsEnabled: false
+    fullScopeAllowed: false
+    rootUrl: "$(env:APPS_FRONTEND_URL_GREETME:https://localhost:9443/apps/greet-me)"
+    baseUrl: "/?realm=acme-internal&scope=openid"
+    adminUrl: ""
+    redirectUris:
+      - "/*"
+    webOrigins:
+      - "+"
+    defaultClientScopes:
+      - "email"
+    optionalClientScopes:
+      - "phone"
+      - "name"
+      - "acme.api"
+      - "address"
+    attributes:
+      "pkce.code.challenge.method": "S256"
+      "post.logout.redirect.uris": "+"
+```
+To ensure the sub claim is present, update the defaultClientScopes to include the basic scope,
+```yaml
+   - clientId: app-greetme
+     protocol: openid-connect
+     name: Acme Greet Me
+     description: "App Greet Me Description"
+     enabled: true
+     publicClient: true
+     standardFlowEnabled: true
+     directAccessGrantsEnabled: false
+     alwaysDisplayInConsole: true
+     serviceAccountsEnabled: false
+     fullScopeAllowed: false
+     rootUrl: "$(env:APPS_FRONTEND_URL_GREETME:https://localhost:9443/apps/greet-me)"
+     baseUrl: "/?realm=acme-internal&scope=openid"
+     adminUrl: ""
+     redirectUris:
+       - "/*"
+     webOrigins:
+       - "+"
+     defaultClientScopes:
+       - "basic"
+       - "email"
+     optionalClientScopes:
+       - "phone"
+       - "name"
+       - "acme.api"
+       - "address"
+     attributes:
+       "pkce.code.challenge.method": "S256"
+       "post.logout.redirect.uris": "+"
+```
+
+
+
+
+
+
+


### PR DESCRIPTION
**What this PR does / why we need it**: with the introduction of the dedicated "basic" scope in Keycloak, existing realm configurations with custom clients might not contain the `sub` claim anymore

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1072 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
