### PR TITLE
fix service account user always triggers user events

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,7 +251,7 @@ jobs:
         run: ./mvnw ${MAVEN_CLI_OPTS} -Dkeycloak.version=${{ matrix.env.KEYCLOAK_VERSION }} -Dkeycloak.client.version=${{ matrix.env.KEYCLOAK_CLIENT_VERSION }} -Dkeycloak.dockerTagSuffix="-legacy" ${ADJUSTED_RESTEASY_VERSION} clean verify ${COMPATIBILITY_PROFILE}
 
   lint-other-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+-  Fix Service Account User always triggers UPDATE USER event [#878](https://github.com/adorsys/keycloak-config-cli/issues/878)
 ### Added
 - Publish charts with github pages [#941](https://github.com/adorsys/keycloak-config-cli/issues/941)
 

--- a/src/main/java/de/adorsys/keycloak/config/repository/UserRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/UserRepository.java
@@ -56,6 +56,13 @@ public class UserRepository {
             user = Optional.of(foundUsers.get(0));
         }
 
+        // Retrieve the service account client id if it exists
+        user.ifPresent(u -> {
+            UserResource userResource = usersResource.get(u.getId());
+            UserRepresentation userRepresentation = userResource.toRepresentation();
+            u.setServiceAccountClientId(userRepresentation.getServiceAccountClientId());
+        });
+
         return user;
     }
 

--- a/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
@@ -169,7 +169,13 @@ public class RealmImportService {
         if (realmImport.isEventsEnabled() != null) return;
 
         Boolean existingEventsEnabled = realmRepository.get(realmImport.getRealm()).isEventsEnabled();
-        realmImport.setEventsEnabled(existingEventsEnabled);
+        if (existingEventsEnabled != null) {
+            realmImport.setEventsEnabled(existingEventsEnabled);
+        } else {
+            realmImport.setEventsEnabled(false);
+            logger.warn("Events enabled status is null for realm '{}'. " + "Setting to false by default.", realmImport.getRealm());
+        }
+
     }
 
     private void createRealm(RealmImport realmImport) {

--- a/src/main/java/de/adorsys/keycloak/config/service/UserImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/UserImportService.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 public class UserImportService {
     private static final Logger logger = LoggerFactory.getLogger(UserImportService.class);
 
-    private static final String[] IGNORED_PROPERTIES_FOR_UPDATE = {"realmRoles", "clientRoles"};
+    private static final String[] IGNORED_PROPERTIES_FOR_UPDATE = {"realmRoles", "clientRoles", "serviceAccountClientId", "attributes"};
     private static final String USER_LABEL_FOR_INITIAL_CREDENTIAL = "initial";
 
     private final RealmRepository realmRepository;
@@ -158,6 +158,9 @@ public class UserImportService {
                         .toList();
                 patchedUser.setCredentials(userCredentials.isEmpty() ? null : userCredentials);
             }
+
+            logger.debug("Existing user: {}", existingUser);
+            logger.debug("Patched user: {}", patchedUser);
 
             if (!CloneUtil.deepEquals(existingUser, patchedUser, "access")) {
                 logger.debug("Update user '{}' in realm '{}'", userToImport.getUsername(), realmName);

--- a/src/main/java/de/adorsys/keycloak/config/service/checksum/ChecksumService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/checksum/ChecksumService.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.text.MessageFormat;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -54,6 +55,11 @@ public class ChecksumService {
         RealmRepresentation existingRealm = realmRepository.get(realmImport.getRealm());
         Map<String, String> customAttributes = existingRealm.getAttributes();
 
+        if (customAttributes == null) {
+            customAttributes = new HashMap<>();
+            existingRealm.setAttributes(customAttributes);
+        }
+
         String importChecksum = realmImport.getChecksum();
         String attributeKey = getCustomAttributeKey(realmImport);
         customAttributes.put(attributeKey, importChecksum);
@@ -68,6 +74,11 @@ public class ChecksumService {
             throw new InvalidImportException("The specified realm does not exist: " + realmImport.getRealm());
         }
         Map<String, String> customAttributes = existingRealm.getAttributes();
+
+        if (customAttributes == null) {
+            customAttributes = new HashMap<>();
+            existingRealm.setAttributes(customAttributes);
+        }
 
         String readChecksum = customAttributes.get(getCustomAttributeKey(realmImport));
         if (readChecksum == null) {

--- a/src/main/java/de/adorsys/keycloak/config/util/CloneUtil.java
+++ b/src/main/java/de/adorsys/keycloak/config/util/CloneUtil.java
@@ -108,6 +108,16 @@ public class CloneUtil {
         logger.trace("objects.deepEquals: ret: {} | origin: {} | other: {} | ignoredProperties: {}",
                 ret, originJsonNode, otherJsonNode, ignoredProperties
         );
+        if (!ret) {
+            logger.debug("Differences detected between origin and other:");
+            originJsonNode.fieldNames().forEachRemaining(fieldName -> {
+                JsonNode originValue = originJsonNode.get(fieldName);
+                JsonNode otherValue = otherJsonNode.get(fieldName);
+                if (!Objects.equals(originValue, otherValue)) {
+                    logger.debug("Field '{}' is different: origin = {}, other = {}", fieldName, originValue, otherValue);
+                }
+            });
+        }
 
         return ret;
     }

--- a/src/test/resources/import-files/users/60.2_update_realm_add_clientl_with_service_account.json
+++ b/src/test/resources/import-files/users/60.2_update_realm_add_clientl_with_service_account.json
@@ -1,0 +1,84 @@
+{
+  "enabled": true,
+  "realm": "realmWithUsers",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": true,
+  "roles": {
+    "client": {
+      "moped-client": [
+        {
+          "name": "test_client_role",
+          "description": "My updated moped-client role",
+          "composite": false,
+          "clientRole": true
+        },
+        {
+          "name": "other_test_client_role",
+          "description": "My changed other moped-client role",
+          "composite": false,
+          "clientRole": true
+        }
+      ]
+    }
+  },
+  "clients": [
+    {
+      "clientId": "technical-client",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "defaultClientScopes": [
+        "role_list",
+        "roles"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "clientId": "moped-client",
+      "name": "moped-client",
+      "description": "Moped-Client",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "my-special-client-secret",
+      "bearerOnly": true,
+      "redirectUris": [],
+      "webOrigins": []
+    }
+  ],
+  "users": [
+    {
+      "username": "service-account-technical-client",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "technical-client",
+      "clientRoles": {
+        "account": [
+          "manage-account",
+          "view-profile"
+        ],
+        "moped-client": [
+          "test_client_role",
+          "other_test_client_role"
+        ],
+        "realm-management": [
+          "view-realm"
+        ]
+      },
+      "notBefore": 0
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:  fix service Account User which always triggers update of user events.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #878 

**Special notes for your reviewer**:
other events may still occur due to other properties, as the realm export from Keycloak contains properties that users may not have defined in the realm configuration.
![image](https://github.com/user-attachments/assets/b3f88ce6-a3bf-4f36-84f6-cb828e5ed153)


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
