### PR TITLE
feat: register Keycloak `JacksonProvider` to prevent failing on unknown properties

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -278,7 +278,7 @@ jobs:
 
       - uses: actions/setup-python@v5.3.0
         with:
-          python-version: 3.7
+          python-version: 3.14
 
       - uses: actions/cache@v4.2.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -278,7 +278,7 @@ jobs:
 
       - uses: actions/setup-python@v5.3.0
         with:
-          python-version: 3.14
+          python-version: 3.10.16
 
       - uses: actions/cache@v4.2.0
         with:

--- a/src/main/java/de/adorsys/keycloak/config/provider/KeycloakProvider.java
+++ b/src/main/java/de/adorsys/keycloak/config/provider/KeycloakProvider.java
@@ -28,6 +28,7 @@ import dev.failsafe.RetryPolicy;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.client.jaxrs.internal.BasicAuthentication;
+import org.keycloak.admin.client.JacksonProvider;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.slf4j.Logger;
@@ -76,6 +77,7 @@ public class KeycloakProvider implements AutoCloseable {
     public Keycloak getInstance() {
         if (keycloak == null || resteasyClient == null || keycloak.isClosed() || resteasyClient.isClosed()) {
             resteasyClient = resteasyClientSupplier.get();
+            resteasyClient.register(JacksonProvider.class);
             keycloak = createKeycloak();
 
             checkServerVersion();


### PR DESCRIPTION
**What this PR does / why we need it**:

Keycloak client version requires updating unless we silently ignore unknown properties.

````
jakarta.ws.rs.client.ResponseProcessingException: jakarta.ws.rs.ProcessingException: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "verifiableCredentialsEnabled" (class org.keycloak.representations.idm.RealmRepresentation), not marked as ignorable (144 known properties: "userFederationMappers", "rememberMe", "duplicateEmailsAllowed", "adminEventsDetailsEnabled", "users", "clientOfflineSessionMaxLifespan", "webAuthnPolicyRequireResidentKey", "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister", "components", "otpPolicyType", "accessCodeLifespanUserAction", "id", "webAuthnPolicyAttestationConveyancePreference", "enabledEventTypes", "applications", "webAuthnPolicyPasswordlessSignatureAlgorithms", "eventsListeners", "ssoSessionMaxLifespanRememberMe", "defaultDefaultClientScopes", "webAuthnPolicyPasswordlessCreateTimeout", "clientOfflineSessionIdleTimeout", "notBefore", "publicKey", "smtpServer", "clientPolicies", "resetPasswordAllowed", "webAuthnPolicyAvoidSameAuthenticatorRegister", "accessTokenLifespanForImplicitFlow", "webAuthnPolicyPasswordlessUserVerificationRequirement", "clientScopes", "internationalizationEnabled", "defaultRole", "accessTokenLifespan", "passwordCredentialGrantAllowed", "federatedUsers", "applicationScopeMappings" [truncated]])
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5296] (through reference chain: org.keycloak.representations.idm.RealmRepresentation["verifiableCredentialsEnabled"])
````
Which issue this PR fixes: fixes https://github.com/adorsys/keycloak-config-cli/issues/1253

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
