### PR TITLE
fix: update org.springframework.boot to 3.2.9 due to CVE-2024-38807

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [6.3.0] - 2025-02-03
 ### Fixed
+- Fix high level CVE (CVE-2024-38807)
+
+### Fixed
 - fix chart publish failure
 ### Added
 - added migration guide for keycloak 25.0.1 [#1072](https://github.com/adorsys/keycloak-config-cli/issues/1072)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.9</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed CVE-2024-38807, caused by v3.2.3 of `org.springframework.boot`

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR

**How to validate**
Notice that the high level CVE (CVE-2024-38807) is no longer present on the docker image:
```bash
docker build -t keycloak-config-cli .
trivy image keycloak-config-cli
```
The output:
> keycloak-config-cli (ubuntu 24.04)
> 
> Total: 45 (UNKNOWN: 0, LOW: 26, MEDIUM: 19, HIGH: 0, CRITICAL: 0)
