### PR TITLE
Prevent querying all clients on searching matching client composites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [6.4.1] - 2025-03-27
+### Fixed
+- Prevent querying all clients twice in `findClientComposites`
+
 ## [6.4.0] - 2025-02-21
 ### Added
 - Allow a user's username to be updated through the config [#810](https://github.com/adorsys/keycloak-config-cli/issues/810)


### PR DESCRIPTION
**What this PR does / why we need it**:

As the number of clients in our realms increases, we noticed that the time to run the configuration job increased as well, even though we were omitting the clients from the config JSON. We noticed that the `RoleImportService` step was taking a much longer time than the other steps.

This change updates the `RealmCompositeRepository` to instead get the realm composites and query the clients based on that, instead of getting all the clients and checking against the `RoleResource` to see if it is a composite. This results in a much faster execution of the role import step.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
