### PR TITLE
Add subGroup as managed properties

### DIFF
--- a/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
+++ b/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
@@ -122,6 +122,9 @@ public class ImportConfigProperties {
         private final ImportManagedPropertiesValues group;
 
         @NotNull
+        private final ImportManagedPropertiesValues subGroup;
+
+        @NotNull
         private final ImportManagedPropertiesValues clientScope;
 
         @NotNull
@@ -165,6 +168,7 @@ public class ImportConfigProperties {
 
         public ImportManagedProperties(@DefaultValue("FULL") ImportManagedPropertiesValues requiredAction,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues group,
+                                       @DefaultValue("FULL") ImportManagedPropertiesValues subGroup,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues clientScope,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues scopeMapping,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues clientScopeMapping,
@@ -181,6 +185,7 @@ public class ImportConfigProperties {
                                        @DefaultValue("FULL") ImportManagedPropertiesValues messageBundles) {
             this.requiredAction = requiredAction;
             this.group = group;
+            this.subGroup = subGroup;
             this.clientScope = clientScope;
             this.scopeMapping = scopeMapping;
             this.clientScopeMapping = clientScopeMapping;
@@ -227,6 +232,10 @@ public class ImportConfigProperties {
 
         public ImportManagedPropertiesValues getGroup() {
             return group;
+        }
+
+        public ImportManagedPropertiesValues getSubGroup() {
+            return subGroup;
         }
 
         public ImportManagedPropertiesValues getIdentityProvider() {

--- a/src/main/java/de/adorsys/keycloak/config/service/GroupImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/GroupImportService.java
@@ -418,7 +418,10 @@ public class GroupImportService {
     private void updateSubGroups(String realmName, String parentGroupId, List<GroupRepresentation> subGroups) {
         List<GroupRepresentation> existingSubGroups = groupRepository.getSubGroups(realmName, parentGroupId);
 
-        deleteAllSubGroupsMissingInImport(realmName, subGroups, existingSubGroups);
+
+        if (importConfigProperties.getManaged().getSubGroup() == ImportManagedPropertiesValues.FULL) {
+            deleteAllSubGroupsMissingInImport(realmName, subGroups, existingSubGroups);
+        }
 
         Set<String> existingSubGroupNames = existingSubGroups.stream()
                 .map(GroupRepresentation::getName)

--- a/src/test/java/de/adorsys/keycloak/config/properties/ImportConfigPropertiesTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/properties/ImportConfigPropertiesTest.java
@@ -59,6 +59,7 @@ import static org.hamcrest.Matchers.is;
         "import.remote-state.encryption-salt=0123456789ABCDEFabcdef",
         "import.managed.authentication-flow=no-delete",
         "import.managed.group=no-delete",
+        "import.managed.sub-group=no-delete",
         "import.managed.required-action=no-delete",
         "import.managed.client-scope=no-delete",
         "import.managed.scope-mapping=no-delete",
@@ -101,6 +102,7 @@ class ImportConfigPropertiesTest {
         assertThat(properties.getRemoteState().getEncryptionSalt(), is("0123456789ABCDEFabcdef"));
         assertThat(properties.getManaged().getAuthenticationFlow(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getGroup(), is(ImportManagedPropertiesValues.NO_DELETE));
+        assertThat(properties.getManaged().getSubGroup(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getRequiredAction(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getClientScope(), is(ImportManagedPropertiesValues.NO_DELETE));
         assertThat(properties.getManaged().getScopeMapping(), is(ImportManagedPropertiesValues.NO_DELETE));


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, only the `groups` attribute is managed. However, it can be interesting to allow the `subGroups` to be managed in the same way. This will allow the usage of multiple file containing specific subGroup configuration.

For instance, you can have a federation that is retrieving groups from an LDAP directory. Some on those groups must be updated to provided some specific roles. However, for lisibility, you want the groups from LDAP to be subgroups of a global container group. Additionaly, for maintenance purpose, you prefer to have one configuration file per LDAP group.

File 1:
```
{
  "realm": "my-realm",
  "groups": [
    {
      "name": "LDAPSync",
      "path": "/LDAPSync",
      "subGroups": [
        {
          "name": "GROUP_1",
          "path": "/LDAPSync/GROUP_1",
          "subGroups": [],
          "realmRoles": [
            "user"
          ],
          "clientRoles": {
            "my-user-service": [
              "user_read",
              "user_search"
            ]
          }
        }
      ]
    }
  ]
}
```

File 2:
```
{
  "realm": "my-realm",
  "groups": [
    {
      "name": "LDAPSync",
      "path": "/LDAPSync",
      "subGroups": [
        {
          "name": "GROUP_2",
          "path": "/LDAPSync/GROUP_2",
          "subGroups": [],
          "realmRoles": [
            "admin"
          ],
          "clientRoles": {
            "my-user-service": [
              "user_read",
              "user_search",
              "user_update",
              "user_create",
              "user_delete"
            ]
          }
        }
      ]
    }
  ]
}
```

After the import of those two file, with the modification of the subGroup managed propertie value, we will have 1 container group (`LDAPSync`) containing two sub group: `GROUP_1` and `GROUP_2`

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
