### PR TITLE
fixes #1230: Events expiration setting in realm.json is ignored during realm import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- Fix events expiration setting in realm.json is ignored during realm import [#1230](https://github.com/adorsys/keycloak-config-cli/issues/1230)
+
 ## [6.4.0] - 2025-02-21
 ### Added
 - Allow a user's username to be updated through the config [#810](https://github.com/adorsys/keycloak-config-cli/issues/810)

--- a/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
@@ -194,7 +194,7 @@ public class RealmImportService {
 
         RealmRepresentation existingRealm = realmRepository.get(realmImport.getRealm());
 
-        if (existingRealm.getEventsExpiration() != null) {
+        if (realm.getEventsExpiration() == null && existingRealm.getEventsExpiration() != null) {
             realm.setEventsExpiration(existingRealm.getEventsExpiration());
         }
 

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportSimpleRealmIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportSimpleRealmIT.java
@@ -32,6 +32,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import java.io.IOException;
 import java.util.Map;
 
+import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
@@ -279,6 +280,17 @@ class ImportSimpleRealmIT extends AbstractImportIT {
         );
 
         assertThat(thrown.getMessage(), is("Could not find client scope 'non-exist' in realm 'simple'!"));
+    }
+
+    @Test
+    @Order(11)
+    void shouldUpdateEventExpiration() throws IOException {
+        doImport("11.1_update_simple-realm_event_expiration_before.json");
+        var realm = keycloakProvider.getInstance().realm("simple").toRepresentation();
+        assertEquals("event expiration is 1 year before update", 31536000L, (long) realm.getEventsExpiration());
+        doImport("11.1_update_simple-realm_event_expiration_after.json");
+        var realmAfter = keycloakProvider.getInstance().realm("simple").toRepresentation();
+        assertEquals("event expiration should be updated to 90 days",  7776000L, (long) realmAfter.getEventsExpiration());
     }
 
     @Test

--- a/src/test/resources/import-files/simple-realm/11.1_update_simple-realm_event_expiration_after.json
+++ b/src/test/resources/import-files/simple-realm/11.1_update_simple-realm_event_expiration_after.json
@@ -1,0 +1,6 @@
+{
+  "enabled": true,
+  "realm": "simple",
+  "eventsEnabled": true,
+  "eventsExpiration": 7776000
+}

--- a/src/test/resources/import-files/simple-realm/11.1_update_simple-realm_event_expiration_before.json
+++ b/src/test/resources/import-files/simple-realm/11.1_update_simple-realm_event_expiration_before.json
@@ -1,0 +1,6 @@
+{
+  "enabled": true,
+  "realm": "simple",
+  "eventsEnabled": true,
+  "eventsExpiration": 31536000
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoid reverting `eventExpiration` to update `eventExpiration` using this cli.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1230 
Events expiration setting in realm.json is ignored during realm import

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
