### PR TITLE
fixes #1278: Updating attributes of a user, which has no attributes set, will work now

### DIFF
--- a/src/main/java/de/adorsys/keycloak/config/service/UserImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/UserImportService.java
@@ -152,7 +152,7 @@ public class UserImportService {
 
             if (importConfigProperties.getBehaviors().isSkipAttributesForFederatedUser() && patchedUser.getFederationLink() != null) {
                 patchedUser.setAttributes(null);
-            } else if (existingUser.getAttributes() != null && userToImport.getAttributes() != null) {
+            } else if (userToImport.getAttributes() != null) {
                 patchedUser.setAttributes(userToImport.getAttributes());
             }
 

--- a/src/test/resources/import-files/users/61.1_create_realm_with_user_without_attributes.json
+++ b/src/test/resources/import-files/users/61.1_create_realm_with_user_without_attributes.json
@@ -1,0 +1,14 @@
+{
+  "enabled": true,
+  "realm": "realmWithUsers",
+  "internationalizationEnabled": true,
+  "users": [
+    {
+      "username": "myuser61@mail.de",
+      "email": "myuser61@mail.de",
+      "enabled": true,
+      "firstName": "My firstname",
+      "lastName": "My lastname"
+    }
+  ]
+}

--- a/src/test/resources/import-files/users/61.2_update_user_set_attributes.json
+++ b/src/test/resources/import-files/users/61.2_update_user_set_attributes.json
@@ -1,0 +1,19 @@
+{
+  "enabled": true,
+  "realm": "realmWithUsers",
+  "internationalizationEnabled": true,
+  "users": [
+    {
+      "username": "myuser61@mail.de",
+      "email": "myuser61@mail.de",
+      "enabled": true,
+      "firstName": "My firstname",
+      "lastName": "My lastname",
+      "attributes": {
+        "locale": [
+          "de"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it:**
Currently is not possible, to add attributes to an existing user without attributes.

**Which issue this PR fixes** (`optional, in fixes #<issue number>(, fixes #<issue_number>, ...`) _format, will close that issue when PR gets merged_): fixes https://github.com/adorsys/keycloak-config-cli/issues/1278

**Special notes for your reviewer:**

- Copied from this PR because it is stall: https://github.com/adorsys/keycloak-config-cli/pull/1281

**PR Readiness Checklist:**

Complete these before marking the PR as ready to review:

- no need to edit CHANGELOG