### PR TITLE
feat: add support to workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - JavaScript variable substitution support in configuration files [#934](https://github.com/adorsys/keycloak-config-cli/issues/934)
+- Add support for Keycloak Workflows management
 
 ### Fixed
 - Fix issue where empty or null composite realm roles were not being cleared during import

--- a/docs/MANAGED.md
+++ b/docs/MANAGED.md
@@ -59,6 +59,7 @@ In some cases, it is required to include some Keycloak defaults because keycloak
 | Clients Authorization Policies   | -                                                                                | `client-authorization-policies`  |
 | Clients Authorization Scopes     | -                                                                                | `client-authorization-scopes`    |
 | Message Bundles                 | Only message bundles imported with config-cli will be managed/deleted.         | `message-bundles`                |
+| Workflows                       | -                                                                                | `workflow`                       |
 
 ### Disabling Deletion of Managed Entities
 

--- a/src/main/java/de/adorsys/keycloak/config/model/RealmImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/model/RealmImport.java
@@ -41,6 +41,8 @@ public class RealmImport extends RealmRepresentation {
 
     private Map<String, Map<String, String>> messageBundles;
 
+    private List<WorkflowRepresentation> workflows;
+
     private String checksum;
     private String source;
     
@@ -109,5 +111,15 @@ public class RealmImport extends RealmRepresentation {
 
     public void setAdminPermissionsEnabled(Boolean adminPermissionsEnabled) {
         this.adminPermissionsEnabled = adminPermissionsEnabled;
+    }
+
+    public List<WorkflowRepresentation> getWorkflows() {
+        return workflows;
+    }
+
+    @SuppressWarnings("unused")
+    @JsonSetter("workflows")
+    public void setWorkflows(List<WorkflowRepresentation> workflows) {
+        this.workflows = workflows;
     }
 }

--- a/src/main/java/de/adorsys/keycloak/config/model/WorkflowRepresentation.java
+++ b/src/main/java/de/adorsys/keycloak/config/model/WorkflowRepresentation.java
@@ -1,0 +1,253 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2021 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+public class WorkflowRepresentation {
+
+    private String id;
+    private String name;
+    private Boolean enabled;
+    private String on;
+    private WorkflowScheduleRepresentation schedule;
+    private WorkflowConcurrencyRepresentation concurrency;
+
+    @JsonProperty("if")
+    private String condition;
+
+    private List<WorkflowStepRepresentation> steps;
+    private WorkflowStateRepresentation state;
+    private Map<String, List<String>> with;
+    private String cancelInProgress;
+    private String restartInProgress;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getOn() {
+        return on;
+    }
+
+    public void setOn(String on) {
+        this.on = on;
+    }
+
+    public WorkflowScheduleRepresentation getSchedule() {
+        return schedule;
+    }
+
+    public void setSchedule(WorkflowScheduleRepresentation schedule) {
+        this.schedule = schedule;
+    }
+
+    public WorkflowConcurrencyRepresentation getConcurrency() {
+        return concurrency;
+    }
+
+    public void setConcurrency(WorkflowConcurrencyRepresentation concurrency) {
+        this.concurrency = concurrency;
+    }
+
+    public String getCondition() {
+        return condition;
+    }
+
+    public void setCondition(String condition) {
+        this.condition = condition;
+    }
+
+    public List<WorkflowStepRepresentation> getSteps() {
+        return steps;
+    }
+
+    public void setSteps(List<WorkflowStepRepresentation> steps) {
+        this.steps = steps;
+    }
+
+    public WorkflowStateRepresentation getState() {
+        return state;
+    }
+
+    public void setState(WorkflowStateRepresentation state) {
+        this.state = state;
+    }
+
+    public Map<String, List<String>> getWith() {
+        return with;
+    }
+
+    public void setWith(Map<String, List<String>> with) {
+        this.with = with;
+    }
+
+    public String getCancelInProgress() {
+        return cancelInProgress;
+    }
+
+    public void setCancelInProgress(String cancelInProgress) {
+        this.cancelInProgress = cancelInProgress;
+    }
+
+    public String getRestartInProgress() {
+        return restartInProgress;
+    }
+
+    public void setRestartInProgress(String restartInProgress) {
+        this.restartInProgress = restartInProgress;
+    }
+
+    // ---- Nested representations ----
+
+    public static class WorkflowScheduleRepresentation {
+        private String after;
+
+        @JsonProperty("batch-size")
+        private Integer batchSize;
+
+        public String getAfter() {
+            return after;
+        }
+
+        public void setAfter(String after) {
+            this.after = after;
+        }
+
+        public Integer getBatchSize() {
+            return batchSize;
+        }
+
+        public void setBatchSize(Integer batchSize) {
+            this.batchSize = batchSize;
+        }
+    }
+
+    public static class WorkflowConcurrencyRepresentation {
+        @JsonProperty("cancel-in-progress")
+        private String cancelInProgress;
+
+        @JsonProperty("restart-in-progress")
+        private String restartInProgress;
+
+        public String getCancelInProgress() {
+            return cancelInProgress;
+        }
+
+        public void setCancelInProgress(String cancelInProgress) {
+            this.cancelInProgress = cancelInProgress;
+        }
+
+        public String getRestartInProgress() {
+            return restartInProgress;
+        }
+
+        public void setRestartInProgress(String restartInProgress) {
+            this.restartInProgress = restartInProgress;
+        }
+    }
+
+    public static class WorkflowStepRepresentation {
+        private String uses;
+        private String after;
+
+        @JsonProperty("scheduled-at")
+        private Long scheduledAt;
+
+        private String id;
+        private Map<String, List<String>> config;
+
+        public String getUses() {
+            return uses;
+        }
+
+        public void setUses(String uses) {
+            this.uses = uses;
+        }
+
+        public String getAfter() {
+            return after;
+        }
+
+        public void setAfter(String after) {
+            this.after = after;
+        }
+
+        public Long getScheduledAt() {
+            return scheduledAt;
+        }
+
+        public void setScheduledAt(Long scheduledAt) {
+            this.scheduledAt = scheduledAt;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, List<String>> getConfig() {
+            return config;
+        }
+
+        public void setConfig(Map<String, List<String>> config) {
+            this.config = config;
+        }
+    }
+
+    public static class WorkflowStateRepresentation {
+        private List<String> errors;
+
+        public List<String> getErrors() {
+            return errors;
+        }
+
+        public void setErrors(List<String> errors) {
+            this.errors = errors;
+        }
+    }
+}

--- a/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
+++ b/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
@@ -163,6 +163,9 @@ public class ImportConfigProperties {
         @NotNull
         private final ImportManagedPropertiesValues messageBundles;
 
+        @NotNull
+        private final ImportManagedPropertiesValues workflow;
+
         public ImportManagedProperties(@DefaultValue("FULL") ImportManagedPropertiesValues requiredAction,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues group,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues clientScope,
@@ -178,7 +181,8 @@ public class ImportConfigProperties {
                                        @DefaultValue("FULL") ImportManagedPropertiesValues clientAuthorizationResources,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues clientAuthorizationPolicies,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues clientAuthorizationScopes,
-                                       @DefaultValue("FULL") ImportManagedPropertiesValues messageBundles) {
+                                       @DefaultValue("FULL") ImportManagedPropertiesValues messageBundles,
+                                       @DefaultValue("FULL") ImportManagedPropertiesValues workflow) {
             this.requiredAction = requiredAction;
             this.group = group;
             this.clientScope = clientScope;
@@ -195,6 +199,7 @@ public class ImportConfigProperties {
             this.clientAuthorizationPolicies = clientAuthorizationPolicies;
             this.clientAuthorizationScopes = clientAuthorizationScopes;
             this.messageBundles = messageBundles;
+            this.workflow = workflow;
         }
 
         public ImportManagedPropertiesValues getRequiredAction() {
@@ -259,6 +264,10 @@ public class ImportConfigProperties {
 
         public ImportManagedPropertiesValues getMessageBundles() {
             return messageBundles;
+        }
+
+        public ImportManagedPropertiesValues getWorkflow() {
+            return workflow;
         }
 
         public enum ImportManagedPropertiesValues {

--- a/src/main/java/de/adorsys/keycloak/config/repository/WorkflowRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/WorkflowRepository.java
@@ -1,0 +1,115 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2021 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.repository;
+
+import de.adorsys.keycloak.config.exception.ImportProcessingException;
+import de.adorsys.keycloak.config.model.WorkflowRepresentation;
+import de.adorsys.keycloak.config.provider.KeycloakProvider;
+import de.adorsys.keycloak.config.resource.WorkflowsResource;
+import de.adorsys.keycloak.config.util.ResponseUtil;
+import org.keycloak.admin.client.CreatedResponseUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+@Service
+@ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "IMPORT", matchIfMissing = true)
+public class WorkflowRepository {
+
+    private static final Logger logger = LoggerFactory.getLogger(WorkflowRepository.class);
+
+    private static final int HTTP_NOT_FOUND = 404;
+    private static final int HTTP_NOT_IMPLEMENTED = 501;
+
+    private final KeycloakProvider keycloakProvider;
+
+    @Autowired
+    public WorkflowRepository(KeycloakProvider keycloakProvider) {
+        this.keycloakProvider = keycloakProvider;
+    }
+
+    /**
+     * Returns all workflows for the realm, or {@code null} if the Workflows feature
+     * is not available on this Keycloak instance (API returns 404/501).
+     */
+    public List<WorkflowRepresentation> getAll(String realmName) {
+        WorkflowsResource resource = keycloakProvider.getCustomApiProxy(WorkflowsResource.class);
+        try {
+            return resource.listWorkflows(realmName, null, null, null, null);
+        } catch (WebApplicationException e) {
+            int status = e.getResponse().getStatus();
+            if (status == HTTP_NOT_FOUND || status == HTTP_NOT_IMPLEMENTED) {
+                logger.debug("Workflows API not available (HTTP {}), skipping", status);
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    public Optional<WorkflowRepresentation> search(String realmName, String workflowName) {
+        WorkflowsResource resource = keycloakProvider.getCustomApiProxy(WorkflowsResource.class);
+        List<WorkflowRepresentation> results = resource.listWorkflows(realmName, workflowName, null, null, true);
+        return results == null ? Optional.empty() : results.stream()
+                .filter(w -> workflowName.equals(w.getName()))
+                .findFirst();
+    }
+
+    public WorkflowRepresentation getById(String realmName, String workflowId) {
+        WorkflowsResource resource = keycloakProvider.getCustomApiProxy(WorkflowsResource.class);
+        try {
+            return resource.getWorkflow(realmName, workflowId, true);
+        } catch (NotFoundException e) {
+            return null;
+        }
+    }
+
+    public void create(String realmName, WorkflowRepresentation workflow) {
+        WorkflowsResource resource = keycloakProvider.getCustomApiProxy(WorkflowsResource.class);
+        try (Response response = resource.createWorkflow(realmName, workflow)) {
+            CreatedResponseUtil.getCreatedId(response);
+        } catch (WebApplicationException error) {
+            String errorMessage = String.format(
+                    "Cannot create workflow '%s' in realm '%s': %s",
+                    workflow.getName(), realmName, ResponseUtil.getErrorMessage(error)
+            );
+            throw new ImportProcessingException(errorMessage, error);
+        }
+    }
+
+    public void update(String realmName, WorkflowRepresentation workflow) {
+        WorkflowsResource resource = keycloakProvider.getCustomApiProxy(WorkflowsResource.class);
+        resource.updateWorkflow(realmName, workflow.getId(), workflow);
+    }
+
+    public void delete(String realmName, String workflowId) {
+        WorkflowsResource resource = keycloakProvider.getCustomApiProxy(WorkflowsResource.class);
+        resource.deleteWorkflow(realmName, workflowId);
+    }
+}

--- a/src/main/java/de/adorsys/keycloak/config/resource/WorkflowsResource.java
+++ b/src/main/java/de/adorsys/keycloak/config/resource/WorkflowsResource.java
@@ -1,0 +1,79 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2021 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.resource;
+
+import de.adorsys.keycloak.config.model.WorkflowRepresentation;
+
+import java.util.List;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * JAX-RS proxy interface for the Keycloak Workflows REST API
+ * (/admin/realms/{realm}/workflows).
+ */
+public interface WorkflowsResource {
+
+    @GET
+    @Path("/admin/realms/{realm}/workflows")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<WorkflowRepresentation> listWorkflows(
+            @PathParam("realm") String realm,
+            @QueryParam("search") String search,
+            @QueryParam("first") Integer first,
+            @QueryParam("max") Integer max,
+            @QueryParam("exact") Boolean exact);
+
+    @POST
+    @Path("/admin/realms/{realm}/workflows")
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response createWorkflow(@PathParam("realm") String realm, WorkflowRepresentation workflow);
+
+    @GET
+    @Path("/admin/realms/{realm}/workflows/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    WorkflowRepresentation getWorkflow(
+            @PathParam("realm") String realm,
+            @PathParam("id") String id,
+            @QueryParam("includeId") Boolean includeId);
+
+    @PUT
+    @Path("/admin/realms/{realm}/workflows/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateWorkflow(
+            @PathParam("realm") String realm,
+            @PathParam("id") String id,
+            WorkflowRepresentation workflow);
+
+    @DELETE
+    @Path("/admin/realms/{realm}/workflows/{id}")
+    void deleteWorkflow(@PathParam("realm") String realm, @PathParam("id") String id);
+}

--- a/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
@@ -87,6 +87,7 @@ public class RealmImportService {
     private final ClientScopeMappingImportService clientScopeMappingImportService;
     private final IdentityProviderImportService identityProviderImportService;
     private final MessageBundleImportService messageBundleImportService;
+    private final WorkflowImportService workflowImportService;
 
     private final ImportConfigProperties importProperties;
 
@@ -115,6 +116,7 @@ public class RealmImportService {
             ClientScopeMappingImportService clientScopeMappingImportService,
             IdentityProviderImportService identityProviderImportService,
             MessageBundleImportService messageBundleImportService,
+            WorkflowImportService workflowImportService,
             OtpPolicyImportService otpPolicyImportService,
             ChecksumService checksumService,
             StateService stateService) {
@@ -138,6 +140,7 @@ public class RealmImportService {
         this.clientScopeMappingImportService = clientScopeMappingImportService;
         this.identityProviderImportService = identityProviderImportService;
         this.messageBundleImportService = messageBundleImportService;
+        this.workflowImportService = workflowImportService;
         this.otpPolicyImportService = otpPolicyImportService;
         this.checksumService = checksumService;
         this.stateService = stateService;
@@ -239,6 +242,7 @@ public class RealmImportService {
         clientScopeMappingImportService.doImport(realmImport);
         clientScopeImportService.doRemoveOrphan(realmImport);
         messageBundleImportService.doImport(realmImport);
+        workflowImportService.doImport(realmImport);
 
         stateService.doImport(realmImport);
         checksumService.doImport(realmImport);

--- a/src/main/java/de/adorsys/keycloak/config/service/WorkflowImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/WorkflowImportService.java
@@ -1,0 +1,117 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2021 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.service;
+
+import de.adorsys.keycloak.config.model.RealmImport;
+import de.adorsys.keycloak.config.model.WorkflowRepresentation;
+import de.adorsys.keycloak.config.properties.ImportConfigProperties;
+import de.adorsys.keycloak.config.repository.WorkflowRepository;
+import de.adorsys.keycloak.config.util.CloneUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static de.adorsys.keycloak.config.properties.ImportConfigProperties.ImportManagedProperties.ImportManagedPropertiesValues;
+
+@Service
+@ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "IMPORT", matchIfMissing = true)
+public class WorkflowImportService {
+    private static final Logger logger = LoggerFactory.getLogger(WorkflowImportService.class);
+
+    private final WorkflowRepository workflowRepository;
+    private final ImportConfigProperties importConfigProperties;
+
+    @Autowired
+    public WorkflowImportService(WorkflowRepository workflowRepository, ImportConfigProperties importConfigProperties) {
+        this.workflowRepository = workflowRepository;
+        this.importConfigProperties = importConfigProperties;
+    }
+
+    public void doImport(RealmImport realmImport) {
+        List<WorkflowRepresentation> workflows = realmImport.getWorkflows();
+        if (workflows == null) return;
+
+        String realmName = realmImport.getRealm();
+        List<WorkflowRepresentation> existingWorkflows = workflowRepository.getAll(realmName);
+
+        if (existingWorkflows == null) {
+            logger.warn("Workflows API not available in realm '{}', skipping workflow import", realmName);
+            return;
+        }
+
+        if (importConfigProperties.getManaged().getWorkflow() == ImportManagedPropertiesValues.FULL) {
+            deleteWorkflowsMissingInImport(realmName, workflows, existingWorkflows);
+        }
+
+        for (WorkflowRepresentation workflow : workflows) {
+            createOrUpdateWorkflow(realmName, workflow);
+        }
+    }
+
+    private void deleteWorkflowsMissingInImport(
+            String realmName,
+            List<WorkflowRepresentation> workflows,
+            List<WorkflowRepresentation> existingWorkflows
+    ) {
+        for (WorkflowRepresentation existing : existingWorkflows) {
+            if (!hasWorkflowWithName(workflows, existing.getName())) {
+                logger.debug("Delete workflow '{}' in realm '{}'", existing.getName(), realmName);
+                workflowRepository.delete(realmName, existing.getId());
+            }
+        }
+    }
+
+    private void createOrUpdateWorkflow(String realmName, WorkflowRepresentation workflow) {
+        Optional<WorkflowRepresentation> maybeExisting = workflowRepository.search(realmName, workflow.getName());
+
+        if (maybeExisting.isPresent()) {
+            updateWorkflowIfNecessary(realmName, workflow, maybeExisting.get());
+        } else {
+            logger.debug("Create workflow '{}' in realm '{}'", workflow.getName(), realmName);
+            workflowRepository.create(realmName, workflow);
+        }
+    }
+
+    private void updateWorkflowIfNecessary(
+            String realmName,
+            WorkflowRepresentation workflow,
+            WorkflowRepresentation existingWorkflow
+    ) {
+        WorkflowRepresentation patched = CloneUtil.patch(existingWorkflow, workflow, "id");
+
+        if (CloneUtil.deepEquals(existingWorkflow, patched)) {
+            logger.debug("No need to update workflow '{}' in realm '{}'", workflow.getName(), realmName);
+        } else {
+            logger.debug("Update workflow '{}' in realm '{}'", workflow.getName(), realmName);
+            workflowRepository.update(realmName, patched);
+        }
+    }
+
+    private boolean hasWorkflowWithName(List<WorkflowRepresentation> workflows, String name) {
+        return workflows.stream().anyMatch(w -> Objects.equals(w.getName(), name));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,6 +54,7 @@ import.managed.client-authorization-resources=full
 import.managed.client-authorization-policies=full
 import.managed.client-authorization-scopes=full
 import.managed.message-bundles=full
+import.managed.workflow=full
 
 logging.group.http=org.apache.http.wire
 logging.group.realm-config=de.adorsys.keycloak.config.provider.KeycloakImportProvider

--- a/src/test/java/de/adorsys/keycloak/config/repository/WorkflowRepositoryTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/repository/WorkflowRepositoryTest.java
@@ -1,0 +1,223 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2021 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.repository;
+
+import de.adorsys.keycloak.config.model.WorkflowRepresentation;
+import de.adorsys.keycloak.config.model.WorkflowRepresentation.WorkflowConcurrencyRepresentation;
+import de.adorsys.keycloak.config.model.WorkflowRepresentation.WorkflowScheduleRepresentation;
+import de.adorsys.keycloak.config.model.WorkflowRepresentation.WorkflowStateRepresentation;
+import de.adorsys.keycloak.config.model.WorkflowRepresentation.WorkflowStepRepresentation;
+import de.adorsys.keycloak.config.provider.KeycloakProvider;
+import de.adorsys.keycloak.config.resource.WorkflowsResource;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class WorkflowRepositoryTest {
+
+    private final KeycloakProvider keycloakProvider = mock(KeycloakProvider.class);
+    private final WorkflowsResource workflowsResource = mock(WorkflowsResource.class);
+    private final WorkflowRepository repository = new WorkflowRepository(keycloakProvider);
+
+    private static final String REALM_NAME = "master";
+    private static final String WORKFLOW_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    private static final String WORKFLOW_NAME = "delete-inactive-users";
+
+    @BeforeEach
+    void setUp() {
+        when(keycloakProvider.getCustomApiProxy(WorkflowsResource.class)).thenReturn(workflowsResource);
+    }
+
+    @Test
+    void getAllShouldReturnWorkflows() {
+        WorkflowRepresentation wf = workflow(WORKFLOW_NAME, WORKFLOW_ID);
+        when(workflowsResource.listWorkflows(REALM_NAME, null, null, null, null)).thenReturn(List.of(wf));
+
+        List<WorkflowRepresentation> result = repository.getAll(REALM_NAME);
+
+        assertThat(result).hasSize(1).first().extracting(WorkflowRepresentation::getName).isEqualTo(WORKFLOW_NAME);
+    }
+
+    @Test
+    void getAllShouldReturnNullWhenApiNotFound() {
+        WebApplicationException notFound = webException(404);
+        when(workflowsResource.listWorkflows(REALM_NAME, null, null, null, null)).thenThrow(notFound);
+
+        assertThat(repository.getAll(REALM_NAME)).isNull();
+    }
+
+    @Test
+    void getAllShouldReturnNullWhenApiNotImplemented() {
+        WebApplicationException notImplemented = webException(501);
+        when(workflowsResource.listWorkflows(REALM_NAME, null, null, null, null)).thenThrow(notImplemented);
+
+        assertThat(repository.getAll(REALM_NAME)).isNull();
+    }
+
+    @Test
+    void getAllShouldRethrowOnOtherErrors() {
+        WebApplicationException serverError = webException(500);
+        when(workflowsResource.listWorkflows(REALM_NAME, null, null, null, null)).thenThrow(serverError);
+
+        assertThatThrownBy(() -> repository.getAll(REALM_NAME)).isInstanceOf(WebApplicationException.class);
+    }
+
+    @Test
+    void searchShouldReturnMatchingWorkflow() {
+        WorkflowRepresentation wf = workflow(WORKFLOW_NAME, WORKFLOW_ID);
+        when(workflowsResource.listWorkflows(REALM_NAME, WORKFLOW_NAME, null, null, true)).thenReturn(List.of(wf));
+
+        Optional<WorkflowRepresentation> result = repository.search(REALM_NAME, WORKFLOW_NAME);
+
+        assertThat(result).isPresent().get().extracting(WorkflowRepresentation::getId).isEqualTo(WORKFLOW_ID);
+    }
+
+    @Test
+    void searchShouldReturnEmptyWhenNullResponse() {
+        when(workflowsResource.listWorkflows(REALM_NAME, WORKFLOW_NAME, null, null, true)).thenReturn(null);
+
+        assertThat(repository.search(REALM_NAME, WORKFLOW_NAME)).isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnEmptyWhenNameNotMatched() {
+        when(workflowsResource.listWorkflows(REALM_NAME, WORKFLOW_NAME, null, null, true))
+                .thenReturn(List.of(workflow("other-workflow", WORKFLOW_ID)));
+
+        assertThat(repository.search(REALM_NAME, WORKFLOW_NAME)).isEmpty();
+    }
+
+    @Test
+    void getByIdShouldReturnWorkflow() {
+        WorkflowRepresentation wf = workflow(WORKFLOW_NAME, WORKFLOW_ID);
+        when(workflowsResource.getWorkflow(REALM_NAME, WORKFLOW_ID, true)).thenReturn(wf);
+
+        assertThat(repository.getById(REALM_NAME, WORKFLOW_ID)).isEqualTo(wf);
+    }
+
+    @Test
+    void getByIdShouldReturnNullWhenNotFound() {
+        when(workflowsResource.getWorkflow(REALM_NAME, WORKFLOW_ID, true)).thenThrow(new NotFoundException());
+
+        assertThat(repository.getById(REALM_NAME, WORKFLOW_ID)).isNull();
+    }
+
+    @Test
+    void updateShouldDelegateToResource() {
+        WorkflowRepresentation wf = workflow(WORKFLOW_NAME, WORKFLOW_ID);
+
+        repository.update(REALM_NAME, wf);
+
+        verify(workflowsResource).updateWorkflow(REALM_NAME, WORKFLOW_ID, wf);
+    }
+
+    @Test
+    void deleteShouldDelegateToResource() {
+        repository.delete(REALM_NAME, WORKFLOW_ID);
+
+        verify(workflowsResource).deleteWorkflow(REALM_NAME, WORKFLOW_ID);
+    }
+
+    @Test
+    void workflowRepresentationRoundTrip() {
+        WorkflowRepresentation wf = new WorkflowRepresentation();
+        wf.setOn("user-authenticated");
+        wf.setCondition("has-user-attribute(type:user)");
+        wf.setWith(Map.of("param", List.of("value")));
+        wf.setCancelInProgress("false");
+        wf.setRestartInProgress("true");
+
+        WorkflowScheduleRepresentation schedule = new WorkflowScheduleRepresentation();
+        wf.setSchedule(schedule);
+        WorkflowConcurrencyRepresentation concurrency = new WorkflowConcurrencyRepresentation();
+        wf.setConcurrency(concurrency);
+        WorkflowStepRepresentation step = new WorkflowStepRepresentation();
+        wf.setSteps(List.of(step));
+        WorkflowStateRepresentation state = new WorkflowStateRepresentation();
+        wf.setState(state);
+
+        assertThat(wf.getOn()).isEqualTo("user-authenticated");
+        assertThat(wf.getCondition()).isEqualTo("has-user-attribute(type:user)");
+        assertThat(wf.getWith()).containsKey("param");
+        assertThat(wf.getCancelInProgress()).isEqualTo("false");
+        assertThat(wf.getRestartInProgress()).isEqualTo("true");
+        assertThat(wf.getSchedule()).isEqualTo(schedule);
+        assertThat(wf.getConcurrency()).isEqualTo(concurrency);
+        assertThat(wf.getSteps()).containsExactly(step);
+        assertThat(wf.getState()).isEqualTo(state);
+    }
+
+    @Test
+    void workflowRepresentationNestedClassesRoundTrip() {
+        WorkflowScheduleRepresentation schedule = new WorkflowScheduleRepresentation();
+        schedule.setAfter("5y");
+        schedule.setBatchSize(50);
+        assertThat(schedule.getAfter()).isEqualTo("5y");
+        assertThat(schedule.getBatchSize()).isEqualTo(50);
+
+        WorkflowConcurrencyRepresentation concurrency = new WorkflowConcurrencyRepresentation();
+        concurrency.setCancelInProgress("true");
+        concurrency.setRestartInProgress("false");
+        assertThat(concurrency.getCancelInProgress()).isEqualTo("true");
+        assertThat(concurrency.getRestartInProgress()).isEqualTo("false");
+
+        WorkflowStepRepresentation step = new WorkflowStepRepresentation();
+        step.setId("step-1");
+        step.setUses("delete-user");
+        step.setAfter("1y");
+        step.setScheduledAt(1234567890L);
+        step.setConfig(Map.of("key", List.of("value")));
+        assertThat(step.getId()).isEqualTo("step-1");
+        assertThat(step.getUses()).isEqualTo("delete-user");
+        assertThat(step.getAfter()).isEqualTo("1y");
+        assertThat(step.getScheduledAt()).isEqualTo(1234567890L);
+        assertThat(step.getConfig()).containsKey("key");
+
+        WorkflowStateRepresentation state = new WorkflowStateRepresentation();
+        state.setErrors(List.of("timeout-error"));
+        assertThat(state.getErrors()).containsExactly("timeout-error");
+    }
+
+    private WorkflowRepresentation workflow(String name, String id) {
+        WorkflowRepresentation wf = new WorkflowRepresentation();
+        wf.setId(id);
+        wf.setName(name);
+        return wf;
+    }
+
+    private WebApplicationException webException(int status) {
+        Response response = mock(Response.class);
+        when(response.getStatus()).thenReturn(status);
+        WebApplicationException exception = mock(WebApplicationException.class);
+        when(exception.getResponse()).thenReturn(response);
+        return exception;
+    }
+}

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportWorkflowsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportWorkflowsIT.java
@@ -1,0 +1,121 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2021 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.service;
+
+import de.adorsys.keycloak.config.AbstractImportIT;
+import de.adorsys.keycloak.config.model.WorkflowRepresentation;
+import de.adorsys.keycloak.config.repository.WorkflowRepository;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@SuppressWarnings("java:S5961")
+@TestPropertySource(properties = {
+        "import.managed.workflow=full"
+})
+class ImportWorkflowsIT extends AbstractImportIT {
+    private static final String REALM_NAME = "realmWithWorkflows";
+
+    @Autowired
+    private WorkflowRepository workflowRepository;
+
+    ImportWorkflowsIT() {
+        this.resourcePath = "import-files/workflows";
+    }
+
+    @Test
+    @Order(0)
+    void shouldCreateRealmWithWorkflow() throws IOException {
+        doImport("00_create_realm_with_workflow.json");
+
+        RealmRepresentation createdRealm = keycloakProvider.getInstance().realm(REALM_NAME).toRepresentation();
+        assertThat(createdRealm.getRealm(), is(REALM_NAME));
+        assertThat(createdRealm.isEnabled(), is(true));
+
+        List<WorkflowRepresentation> workflows = workflowRepository.getAll(REALM_NAME);
+        assumeTrue(workflows != null, "Workflows API not available on this Keycloak version");
+
+        assertThat(workflows, hasSize(1));
+
+        WorkflowRepresentation workflow = workflows.get(0);
+        assertThat(workflow.getName(), is("Delete inactive users"));
+        assertThat(workflow.getEnabled(), is(true));
+        assertThat(workflow.getOn(), is("user-authenticated"));
+        assertThat(workflow.getCondition(), is("has-user-attribute(type:user)"));
+        assertThat(workflow.getSchedule().getAfter(), is("5y"));
+        assertThat(workflow.getSchedule().getBatchSize(), is(50));
+        assertThat(workflow.getConcurrency().getRestartInProgress(), is("true"));
+        assertThat(workflow.getSteps(), hasSize(1));
+        assertThat(workflow.getSteps().get(0).getUses(), is("delete-user"));
+        assertThat(workflow.getSteps().get(0).getAfter(), is("5y"));
+    }
+
+    @Test
+    @Order(1)
+    void shouldNotUpdateUnchangedWorkflow() throws IOException {
+        doImport("00_create_realm_with_workflow.json");
+
+        List<WorkflowRepresentation> workflows = workflowRepository.getAll(REALM_NAME);
+        assumeTrue(workflows != null, "Workflows API not available on this Keycloak version");
+
+        assertThat(workflows, hasSize(1));
+        assertThat(workflows.get(0).getName(), is("Delete inactive users"));
+        assertThat(workflows.get(0).getEnabled(), is(true));
+    }
+
+    @Test
+    @Order(2)
+    void shouldUpdateWorkflow() throws IOException {
+        doImport("01_update_workflow.json");
+
+        List<WorkflowRepresentation> workflows = workflowRepository.getAll(REALM_NAME);
+        assumeTrue(workflows != null, "Workflows API not available on this Keycloak version");
+
+        assertThat(workflows, hasSize(1));
+
+        WorkflowRepresentation workflow = workflows.get(0);
+        assertThat(workflow.getName(), is("Delete inactive users"));
+        assertThat(workflow.getEnabled(), is(false));
+        assertThat(workflow.getSchedule().getAfter(), is("1y"));
+        assertThat(workflow.getSchedule().getBatchSize(), is(100));
+    }
+
+    @Test
+    @Order(3)
+    void shouldDeleteRemovedWorkflow() throws IOException {
+        doImport("02_delete_workflow.json");
+
+        List<WorkflowRepresentation> workflows = workflowRepository.getAll(REALM_NAME);
+        assumeTrue(workflows != null, "Workflows API not available on this Keycloak version");
+
+        assertThat(workflows, hasSize(0));
+    }
+}

--- a/src/test/java/de/adorsys/keycloak/config/service/WorkflowImportServiceTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/WorkflowImportServiceTest.java
@@ -1,0 +1,175 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2021 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.service;
+
+import de.adorsys.keycloak.config.model.RealmImport;
+import de.adorsys.keycloak.config.model.WorkflowRepresentation;
+import de.adorsys.keycloak.config.properties.ImportConfigProperties;
+import de.adorsys.keycloak.config.properties.ImportConfigProperties.ImportManagedProperties;
+import de.adorsys.keycloak.config.properties.ImportConfigProperties.ImportManagedProperties.ImportManagedPropertiesValues;
+import de.adorsys.keycloak.config.repository.WorkflowRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Optional.*;
+import static org.mockito.Mockito.*;
+
+class WorkflowImportServiceTest {
+
+    private final WorkflowRepository workflowRepository = mock(WorkflowRepository.class);
+    private final ImportConfigProperties importConfigProperties = mock(ImportConfigProperties.class);
+    private final ImportManagedProperties managedProperties = mock(ImportManagedProperties.class);
+
+    private final WorkflowImportService service =
+            new WorkflowImportService(workflowRepository, importConfigProperties);
+
+    private static final String REALM_NAME = "master";
+    private static final String WORKFLOW_NAME = "delete-inactive-users";
+    private static final String WORKFLOW_NAME_SECONDARY = "notify-inactive-users";
+    private static final String WORKFLOW_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    private static final String WORKFLOW_ID_SECONDARY = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
+
+    @BeforeEach
+    void setUp() {
+        when(importConfigProperties.getManaged()).thenReturn(managedProperties);
+        when(managedProperties.getWorkflow()).thenReturn(ImportManagedPropertiesValues.FULL);
+    }
+
+    @Test
+    void shouldSkipWhenNoWorkflowsInImport() {
+        RealmImport realmImport = realmImport(null);
+
+        service.doImport(realmImport);
+
+        verifyNoInteractions(workflowRepository);
+    }
+
+    @Test
+    void shouldSkipWhenApiUnavailable() {
+        RealmImport realmImport = realmImport(List.of(workflow(WORKFLOW_NAME, WORKFLOW_ID)));
+        when(workflowRepository.getAll(REALM_NAME)).thenReturn(null);
+
+        service.doImport(realmImport);
+
+        verify(workflowRepository).getAll(REALM_NAME);
+        verify(workflowRepository, never()).create(any(), any());
+        verify(workflowRepository, never()).update(any(), any());
+        verify(workflowRepository, never()).delete(any(), any());
+    }
+
+    @Test
+    void shouldCreateWorkflowWhenNotExisting() {
+        WorkflowRepresentation wf = workflow(WORKFLOW_NAME, null);
+        RealmImport realmImport = realmImport(List.of(wf));
+
+        when(workflowRepository.getAll(REALM_NAME)).thenReturn(List.of());
+        when(workflowRepository.search(REALM_NAME, WORKFLOW_NAME)).thenReturn(empty());
+
+        service.doImport(realmImport);
+
+        verify(workflowRepository).create(REALM_NAME, wf);
+        verify(workflowRepository, never()).update(any(), any());
+    }
+
+    @Test
+    void shouldUpdateWorkflowWhenChanged() {
+        WorkflowRepresentation existing = workflow(WORKFLOW_NAME, WORKFLOW_ID);
+        existing.setEnabled(true);
+
+        WorkflowRepresentation imported = workflow(WORKFLOW_NAME, null);
+        imported.setEnabled(false);
+
+        RealmImport realmImport = realmImport(List.of(imported));
+        when(workflowRepository.getAll(REALM_NAME)).thenReturn(List.of(existing));
+        when(workflowRepository.search(REALM_NAME, WORKFLOW_NAME)).thenReturn(of(existing));
+
+        service.doImport(realmImport);
+
+        verify(workflowRepository, never()).create(any(), any());
+        verify(workflowRepository).update(eq(REALM_NAME), any());
+    }
+
+    @Test
+    void shouldNotUpdateWorkflowWhenUnchanged() {
+        WorkflowRepresentation existing = workflow(WORKFLOW_NAME, WORKFLOW_ID);
+        existing.setEnabled(true);
+
+        WorkflowRepresentation imported = workflow(WORKFLOW_NAME, null);
+        imported.setEnabled(true);
+
+        RealmImport realmImport = realmImport(List.of(imported));
+        when(workflowRepository.getAll(REALM_NAME)).thenReturn(List.of(existing));
+        when(workflowRepository.search(REALM_NAME, WORKFLOW_NAME)).thenReturn(of(existing));
+
+        service.doImport(realmImport);
+
+        verify(workflowRepository, never()).create(any(), any());
+        verify(workflowRepository, never()).update(any(), any());
+    }
+
+    @Test
+    void shouldDeleteWorkflowMissingInImport() {
+        WorkflowRepresentation existing = workflow(WORKFLOW_NAME, WORKFLOW_ID);
+        WorkflowRepresentation imported = workflow(WORKFLOW_NAME_SECONDARY, null);
+
+        RealmImport realmImport = realmImport(List.of(imported));
+        when(workflowRepository.getAll(REALM_NAME)).thenReturn(List.of(existing));
+        when(workflowRepository.search(REALM_NAME, WORKFLOW_NAME_SECONDARY)).thenReturn(empty());
+
+        service.doImport(realmImport);
+
+        verify(workflowRepository).delete(REALM_NAME, WORKFLOW_ID);
+        verify(workflowRepository).create(REALM_NAME, imported);
+    }
+
+    @Test
+    void shouldNotDeleteWhenManagedIsNotFull() {
+        when(managedProperties.getWorkflow()).thenReturn(ImportManagedPropertiesValues.NO_DELETE);
+
+        WorkflowRepresentation existing = workflow(WORKFLOW_NAME, WORKFLOW_ID);
+        WorkflowRepresentation imported = workflow(WORKFLOW_NAME_SECONDARY, null);
+
+        RealmImport realmImport = realmImport(List.of(imported));
+        when(workflowRepository.getAll(REALM_NAME)).thenReturn(List.of(existing));
+        when(workflowRepository.search(REALM_NAME, WORKFLOW_NAME_SECONDARY)).thenReturn(empty());
+
+        service.doImport(realmImport);
+
+        verify(workflowRepository, never()).delete(any(), any());
+        verify(workflowRepository).create(REALM_NAME, imported);
+    }
+
+    private RealmImport realmImport(List<WorkflowRepresentation> workflows) {
+        RealmImport realmImport = new RealmImport();
+        realmImport.setRealm(REALM_NAME);
+        realmImport.setWorkflows(workflows);
+        return realmImport;
+    }
+
+    private WorkflowRepresentation workflow(String name, String id) {
+        WorkflowRepresentation wf = new WorkflowRepresentation();
+        wf.setId(id);
+        wf.setName(name);
+        return wf;
+    }
+}

--- a/src/test/resources/import-files/workflows/00_create_realm_with_workflow.json
+++ b/src/test/resources/import-files/workflows/00_create_realm_with_workflow.json
@@ -1,0 +1,25 @@
+{
+  "enabled": true,
+  "realm": "realmWithWorkflows",
+  "workflows": [
+    {
+      "name": "Delete inactive users",
+      "enabled": true,
+      "on": "user-authenticated",
+      "if": "has-user-attribute(type:user)",
+      "schedule": {
+        "after": "5y",
+        "batch-size": 50
+      },
+      "concurrency": {
+        "restart-in-progress": "true"
+      },
+      "steps": [
+        {
+          "uses": "delete-user",
+          "after": "5y"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/import-files/workflows/01_update_workflow.json
+++ b/src/test/resources/import-files/workflows/01_update_workflow.json
@@ -1,0 +1,25 @@
+{
+  "enabled": true,
+  "realm": "realmWithWorkflows",
+  "workflows": [
+    {
+      "name": "Delete inactive users",
+      "enabled": false,
+      "on": "user-authenticated",
+      "if": "has-user-attribute(type:user)",
+      "schedule": {
+        "after": "1y",
+        "batch-size": 100
+      },
+      "concurrency": {
+        "restart-in-progress": "true"
+      },
+      "steps": [
+        {
+          "uses": "delete-user",
+          "after": "1y"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/import-files/workflows/02_delete_workflow.json
+++ b/src/test/resources/import-files/workflows/02_delete_workflow.json
@@ -1,0 +1,5 @@
+{
+  "enabled": true,
+  "realm": "realmWithWorkflows",
+  "workflows": []
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for managing Keycloak Workflows via keycloak-config-cli. This includes full CRUD lifecycle management (create, update, delete) of workflow entities within a realm import. A new
  WorkflowImportService, WorkflowRepository, WorkflowsResource, and WorkflowRepresentation model are introduced. Workflows are treated as a managed entity with import.managed.workflow=full by default.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1403 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
