### PR TITLE
Fix exception in 'isDefaultRole' when description is null.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix Keycloak compatibility by stripping `clientProfiles` and `clientPolicies` from top-level realm updates
 - Improve idempotency for OTP policy, state, and checksum updates to avoid redundant realm updates
 - Fix issue where empty or null composite realm roles were not being cleared during import
+- Fix exception in 'isDefaultRole' when description is null
 
 ## [6.4.1] - 2026-01-28
 

--- a/src/main/java/de/adorsys/keycloak/config/util/KeycloakUtil.java
+++ b/src/main/java/de/adorsys/keycloak/config/util/KeycloakUtil.java
@@ -46,7 +46,7 @@ public class KeycloakUtil {
     }
 
     public static boolean isDefaultRole(RoleRepresentation role) {
-        if (StringUtils.startsWith(role.getName(), "default-roles-") && role.getDescription().equals("${role_default-roles}")) {
+        if (StringUtils.startsWith(role.getName(), "default-roles-") && StringUtils.equals(role.getDescription(), "${role_default-roles}")) {
             return true;
         }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR avoids a null pointer exception when comparing the description of a role (that could be null) with the string "${role_default-roles}". I ran into this issue while I was updating the version of keycloak-config-cli I use within my deployment and saw that the cause of the error was a realm role I had with null as its description.