### PR TITLE
feat: track groups in remote-state to prevent deletion of UI-created …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 - Fix secrets leak in HTTP debug logs - passwords, tokens, and credentials are now sanitized when `LOGGING_LEVEL_HTTP=debug` is enabled [#1302](https://github.com/adorsys/keycloak-config-cli/issues/1302)
 
-### Fixed
-- fix issue FGAP returns 501 Not implemented for keycloak-26.2.0+ [#1305](https://github.com/adorsys/keycloak-config-cli/issues/1305)
-- Prevent unnecessary authentication flow recreation when only realm-level properties change [#875](https://github.com/adorsys/keycloak-config-cli/issues/875)
 ### Added
+- Track groups in remote-state to prevent deletion of groups created outside config-cli (e.g., via Keycloak UI) [#1400](https://github.com/adorsys/keycloak-config-cli/issues/1400)
 - Add subGroups as managed import properties [#1294](https://github.com/adorsys/keycloak-config-cli/pull/1294)
 - Enhance getting all Clients to remove Flow Override by using pagination by 100 to avoid timeout [#1384](https://github.com/adorsys/keycloak-config-cli/issues/1384)
 - JavaScript variable substitution support in configuration files [#934](https://github.com/adorsys/keycloak-config-cli/issues/934)
@@ -22,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add option to configure ignored user properties during user update (`--import.behaviors.user-update-ignored-properties`) [#910](https://github.com/adorsys/keycloak-config-cli/issues/910)
 
 ### Fixed
+- fix issue FGAP returns 501 Not implemented for keycloak-26.2.0+ [#1305](https://github.com/adorsys/keycloak-config-cli/issues/1305)
+- Prevent unnecessary authentication flow recreation when only realm-level properties change [#875](https://github.com/adorsys/keycloak-config-cli/issues/875)
 - Fix bug where `clientProfiles` and `clientPolicies` were erased when importing multiple realm configuration files
 - Fix Keycloak compatibility by stripping `clientProfiles` and `clientPolicies` from top-level realm updates
 - Improve idempotency for OTP policy, state, and checksum updates to avoid redundant realm updates

--- a/src/main/java/de/adorsys/keycloak/config/service/GroupImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/GroupImportService.java
@@ -26,10 +26,12 @@ import de.adorsys.keycloak.config.model.RealmImport;
 import de.adorsys.keycloak.config.properties.ImportConfigProperties;
 import de.adorsys.keycloak.config.properties.ImportConfigProperties.ImportManagedProperties.ImportManagedPropertiesValues;
 import de.adorsys.keycloak.config.repository.GroupRepository;
+import de.adorsys.keycloak.config.service.state.StateService;
 import de.adorsys.keycloak.config.util.CloneUtil;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -47,15 +49,19 @@ public class GroupImportService {
     private final GroupRepository groupRepository;
     private final ImportConfigProperties importConfigProperties;
     private final ThreadHelper threadHelper;
+    private final StateService stateService;
 
+    @Autowired
     public GroupImportService(
             GroupRepository groupRepository,
             ImportConfigProperties importConfigProperties,
-            ThreadHelper threadHelper
+            ThreadHelper threadHelper,
+            StateService stateService
     ) {
         this.groupRepository = groupRepository;
         this.importConfigProperties = importConfigProperties;
         this.threadHelper = threadHelper;
+        this.stateService = stateService;
     }
 
     public void importGroups(RealmImport realmImport) {
@@ -94,9 +100,20 @@ public class GroupImportService {
             buildGroupPathLookupMap(groupPathMap, groupRep, "/");
         }
 
+        // Get groups that were created by config-cli (tracked in state)
+        List<String> managedGroupNames = stateService.getGroups();
+        boolean useRemoteState = importConfigProperties.getRemoteState().isEnabled() && !managedGroupNames.isEmpty();
+
         for (GroupRepresentation existingGroup : existingGroups) {
             if (groupPathMap.containsKey("/" + existingGroup.getName())) {
                 tryRecursivelyDeletingDanglingSubGroups(groupPathMap, realmName, existingGroup.getId());
+                continue;
+            }
+
+            // If remote-state is enabled, only delete groups that were created by config-cli
+            if (useRemoteState && !managedGroupNames.contains(existingGroup.getName())) {
+                logger.debug("Skip deleting group '{}' in realm '{}' - not managed by config-cli", 
+                        existingGroup.getName(), realmName);
                 continue;
             }
 

--- a/src/main/java/de/adorsys/keycloak/config/service/state/StateService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/state/StateService.java
@@ -76,6 +76,7 @@ public class StateService {
         setComponents(realmImport);
         setClientAuthorizationResources(realmImport);
         setMessageBundles(realmImport);
+        setGroups(realmImport);
 
         stateRepository.update(realmImport);
         logger.debug("Updated states of realm '{}'", realmImport.getRealm());
@@ -236,5 +237,20 @@ public class StateService {
 
     public List<String> getMessageBundles() {
         return stateRepository.getState("message-bundles");
+    }
+
+    public List<String> getGroups() {
+        return stateRepository.getState("groups");
+    }
+
+    private void setGroups(RealmImport realmImport) {
+        List<GroupRepresentation> groups = realmImport.getGroups();
+        if (groups == null) return;
+
+        List<String> state = groups.stream()
+                .map(GroupRepresentation::getName)
+                .toList();
+
+        stateRepository.setState("groups", state);
     }
 }

--- a/src/test/java/de/adorsys/keycloak/config/service/GroupImportServiceTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/GroupImportServiceTest.java
@@ -34,6 +34,7 @@ import de.adorsys.keycloak.config.ThreadHelper;
 import de.adorsys.keycloak.config.exception.ImportProcessingException;
 import de.adorsys.keycloak.config.properties.ImportConfigProperties;
 import de.adorsys.keycloak.config.repository.GroupRepository;
+import de.adorsys.keycloak.config.service.state.StateService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -53,8 +54,10 @@ class GroupImportServiceTest {
 
     private final ThreadHelper threadHelper = mock(ThreadHelper.class);
 
+    private final StateService stateService = mock(StateService.class);
+
     private final GroupImportService groupImportService =
-        new GroupImportService(groupRepository, importConfigProperties, threadHelper);
+        new GroupImportService(groupRepository, importConfigProperties, threadHelper, stateService);
 
     @Nested
     class CreatingGroupIT {


### PR DESCRIPTION
…groups

- Add setGroups() and getGroups() methods to StateService
- Modify GroupImportService to only delete groups tracked in state
- Groups created via Keycloak UI are now preserved when remote-state.enabled=true
- Fixes #1400

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1400

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [X] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
