### PR TITLE
Fix/security update deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 - Update assertj-core from 3.26.3 to 3.27.7 (CVE-2026-24400, XXE vulnerability)
 - Update jackson from 2.17.2 to 2.21.1 (GHSA-72hv-8253-57qq, async parser DoS vulnerability)[#1449](https://github.com/adorsys/keycloak-config-cli/issues/1449)
+- Update logback from 1.5.18 to 1.5.25 (CVE-2025-11226, CVE-2026-1225, GHSA-qqpg-mvqg-649v)
+- Update commons-lang3 from 3.17.0 to 3.18.0 (CVE-2025-48924, uncontrolled recursion)
+- Update nimbus-jose-jwt from 10.0 to 10.0.2 (CVE-2025-53864, DoS via nested JSON)
+- Update rhino from 1.7.7.2 to 1.8.1 (CVE-2025-66453, DoS via toFixed())
 
 ## [6.5.0] - 2026-03-12
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <checkstyle-plugin.version>3.3.1</checkstyle-plugin.version>
         <checkstyle.version>10.17.0</checkstyle.version>
         <commons-text.version>1.12.0</commons-text.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <failsafe.version>3.3.2</failsafe.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <jackson.version>2.21.1</jackson.version>
@@ -102,6 +103,9 @@
         <wiremock-jre8.version>2.27.2</wiremock-jre8.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <assertj.version>3.27.7</assertj.version>
+        <logback.version>1.5.25</logback.version>
+        <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
+        <rhino.version>1.8.1</rhino.version>
 
         <sonar.projectKey>keycloak-config-cli</sonar.projectKey>
         <sonar.organization>adorsys</sonar.organization>
@@ -194,6 +198,18 @@
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
                 <version>${commons-beanutils.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mozilla</groupId>
+                <artifactId>rhino</artifactId>
+                <version>${rhino.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbus-jose-jwt.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
**What this PR does / why we need it**: Updates multiple vulnerable dependencies to their fixed versions to address security CVEs:

- assertj-core: XXE vulnerability (CVE-2026-24400)
- jackson: Async parser DoS vulnerability (GHSA-72hv-8253-57qq)
- logback: ACE vulnerabilities (CVE-2025-11226, CVE-2026-1225, GHSA-qqpg-mvqg-649v)
- commons-lang3: Uncontrolled recursion (CVE-2025-48924)
- nimbus-jose-jwt: DoS via nested JSON (CVE-2025-53864)
- rhino: DoS via toFixed() (CVE-2025-66453)

**Which issue this PR fixes**: fixes #1449 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
