### PR TITLE
fix(ci): publish Helm chart on tag pushes instead of main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -282,7 +282,7 @@ jobs:
 
   publish-helm-chart:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: [build, build-pom-version, lint-other-files]
     steps:
       - uses: actions/checkout@v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- Fix Helm chart not being published to GitHub Pages on releases by publishing from tag pushes instead of main branch [#1356](https://github.com/adorsys/keycloak-config-cli/issues/1356)
+
 ### Security
 - Update assertj-core from 3.26.3 to 3.27.7 (CVE-2026-24400, XXE vulnerability)
 - Update jackson from 2.17.2 to 2.21.1 (GHSA-72hv-8253-57qq, async parser DoS vulnerability)[#1449](https://github.com/adorsys/keycloak-config-cli/issues/1449)


### PR DESCRIPTION
**What this PR does / why we need it**: 

Fix Helm chart not being published to GitHub Pages on releases by publishing from tag pushes instead of main branch 

**Which issue this PR fixes** [#1356](https://github.com/adorsys/keycloak-config-cli/issues/1356)



**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] tests pass locally (`mvn test` or relevant subset)
- [x] added/updated tests for the changes (if applicable)
- [x] documentation has been updated (if applicable)
- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR