### PR TITLE
Fix/first broker login flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Keycloak workflow API documentation differs from actual implementation [#1476](https://github.com/adorsys/keycloak-config-cli/pull/1476)
 - Support for Keycloak 26.5.5 to fix [#1303](https://github.com/adorsys/keycloak-config-cli/issues/1303)
-
+- Fix creation of custom first broker login flow and binding it to realm [#1481](https://github.com/adorsys/keycloak-config-cli/issues/1481)
 
 ### Security
 - Update assertj-core from 3.26.3 to 3.27.7 (CVE-2026-24400, XXE vulnerability)

--- a/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
@@ -124,6 +124,7 @@ public class AuthenticationFlowsImportService {
         realm.setDockerAuthenticationFlow(realmImport.getDockerAuthenticationFlow());
         realm.setRegistrationFlow(realmImport.getRegistrationFlow());
         realm.setResetCredentialsFlow(realmImport.getResetCredentialsFlow());
+        realm.setFirstBrokerLoginFlow(realmImport.getFirstBrokerLoginFlow());
 
         realmRepository.update(realm);
     }
@@ -200,7 +201,7 @@ public class AuthenticationFlowsImportService {
     }
 
     private List<AuthenticationFlowRepresentation> getAllSubFlows(RealmImport realmImport,
-                                                                  AuthenticationFlowRepresentation topLevelFlowToImport) {
+            AuthenticationFlowRepresentation topLevelFlowToImport) {
 
         final List<AuthenticationFlowRepresentation> subFlows = AuthenticationFlowUtil.getSubFlowsForTopLevelFlow(
                 realmImport, topLevelFlowToImport);

--- a/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
@@ -30,6 +30,7 @@ import de.adorsys.keycloak.config.repository.IdentityProviderRepository;
 import de.adorsys.keycloak.config.repository.RealmRepository;
 import de.adorsys.keycloak.config.util.AuthenticationFlowUtil;
 import de.adorsys.keycloak.config.util.CloneUtil;
+// import de.adorsys.keycloak.config.util.VersionUtil;
 import org.keycloak.representations.idm.AuthenticationExecutionExportRepresentation;
 import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
@@ -124,13 +125,51 @@ public class AuthenticationFlowsImportService {
         realm.setDockerAuthenticationFlow(realmImport.getDockerAuthenticationFlow());
         realm.setRegistrationFlow(realmImport.getRegistrationFlow());
         realm.setResetCredentialsFlow(realmImport.getResetCredentialsFlow());
-        realm.setFirstBrokerLoginFlow(realmImport.getFirstBrokerLoginFlow());
+
+        // firstBrokerLoginFlow is only available in Keycloak 24+
+        String firstBrokerLoginFlow = getFirstBrokerLoginFlow(realmImport);
+        if (firstBrokerLoginFlow != null) {
+            setFirstBrokerLoginFlow(realm, firstBrokerLoginFlow);
+        }
 
         realmRepository.update(realm);
     }
 
     /**
-     * creates or updates only the top-level flows and its executions or execution-flows
+     * Gets the firstBrokerLoginFlow using reflection to support Keycloak versions
+     * below 24.
+     */
+    private String getFirstBrokerLoginFlow(RealmImport realmImport) {
+        try {
+            return (String) RealmImport.class.getMethod("getFirstBrokerLoginFlow").invoke(realmImport);
+        } catch (NoSuchMethodException e) {
+            // Method not available in Keycloak < 24
+            return null;
+        } catch (Exception e) {
+            logger.warn("Failed to get firstBrokerLoginFlow: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Sets the firstBrokerLoginFlow using reflection to support Keycloak versions
+     * below 24.
+     */
+    private void setFirstBrokerLoginFlow(RealmRepresentation realm, String firstBrokerLoginFlow) {
+        try {
+            RealmRepresentation.class.getMethod("setFirstBrokerLoginFlow", String.class)
+                    .invoke(realm, firstBrokerLoginFlow);
+        } catch (NoSuchMethodException e) {
+            // Method not available in Keycloak < 24, ignore
+            logger.debug("setFirstBrokerLoginFlow not available in this Keycloak version");
+        } catch (Exception e) {
+            logger.warn("Failed to set firstBrokerLoginFlow: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * creates or updates only the top-level flows and its executions or
+     * execution-flows
      */
     private void createOrUpdateTopLevelFlows(RealmImport realmImport, List<AuthenticationFlowRepresentation> topLevelFlowsToImport) {
         for (AuthenticationFlowRepresentation topLevelFlowToImport : topLevelFlowsToImport) {
@@ -429,7 +468,24 @@ public class AuthenticationFlowsImportService {
                 || flowAlias.equals(realm.getClientAuthenticationFlow())
                 || flowAlias.equals(realm.getDockerAuthenticationFlow())
                 || flowAlias.equals(realm.getRegistrationFlow())
-                || flowAlias.equals(realm.getResetCredentialsFlow());
+                || flowAlias.equals(realm.getResetCredentialsFlow())
+                || flowAlias.equals(getRealmFirstBrokerLoginFlow(realm));
+    }
+
+    /**
+     * Gets the firstBrokerLoginFlow from a RealmRepresentation using reflection to
+     * support Keycloak versions below 24.
+     */
+    private String getRealmFirstBrokerLoginFlow(RealmRepresentation realm) {
+        try {
+            return (String) RealmRepresentation.class.getMethod("getFirstBrokerLoginFlow").invoke(realm);
+        } catch (NoSuchMethodException e) {
+            // Method not available in Keycloak < 24
+            return null;
+        } catch (Exception e) {
+            logger.warn("Failed to get realm firstBrokerLoginFlow: {}", e.getMessage());
+            return null;
+        }
     }
 
     private void deleteTopLevelFlowsMissingInImport(
@@ -445,7 +501,9 @@ public class AuthenticationFlowsImportService {
                 .collect(Collectors.toSet());
 
         for (AuthenticationFlowRepresentation existingTopLevelFlow : existingTopLevelFlows) {
-            if (topLevelFlowsToImportAliases.contains(existingTopLevelFlow.getAlias())) continue;
+            if (topLevelFlowsToImportAliases.contains(existingTopLevelFlow.getAlias())) {
+                continue;
+            }
 
             if (isTemporaryWorkaroundFlow(existingTopLevelFlow.getAlias())) {
                 continue;

--- a/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
@@ -30,7 +30,6 @@ import de.adorsys.keycloak.config.repository.IdentityProviderRepository;
 import de.adorsys.keycloak.config.repository.RealmRepository;
 import de.adorsys.keycloak.config.util.AuthenticationFlowUtil;
 import de.adorsys.keycloak.config.util.CloneUtil;
-// import de.adorsys.keycloak.config.util.VersionUtil;
 import org.keycloak.representations.idm.AuthenticationExecutionExportRepresentation;
 import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;

--- a/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
@@ -41,7 +41,7 @@ import java.lang.reflect.Method;
 @Service
 @ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "IMPORT", matchIfMissing = true)
 public class RealmImportService {
-    static final String[] ignoredPropertiesForRealmImport = new String[]{
+    static final String[] ignoredPropertiesForRealmImport = new String[] {
             "authenticatorConfig",
             "clients",
             "roles",
@@ -56,6 +56,7 @@ public class RealmImportService {
             "dockerAuthenticationFlow",
             "registrationFlow",
             "resetCredentialsFlow",
+            "firstBrokerLoginFlow",
             "components",
             "authenticationFlows",
             "scopeMappings",
@@ -173,14 +174,15 @@ public class RealmImportService {
             logger.debug(
                     "No need to update realm '{}', import checksum same: '{}'",
                     realmImport.getRealm(),
-                    realmImport.getChecksum()
-            );
+                    realmImport.getChecksum());
         }
     }
 
     private void setEventsEnabledWorkaround(RealmImport realmImport) {
         // https://github.com/adorsys/keycloak-config-cli/issues/338
-        if (realmImport.isEventsEnabled() != null) return;
+        if (realmImport.isEventsEnabled() != null) {
+            return;
+        }
 
         Boolean existingEventsEnabled = realmRepository.get(realmImport.getRealm()).isEventsEnabled();
         realmImport.setEventsEnabled(existingEventsEnabled);
@@ -189,10 +191,12 @@ public class RealmImportService {
     private void createRealm(RealmImport realmImport) {
         logger.debug("Creating realm '{}' ...", realmImport.getRealm());
 
-        RealmRepresentation realm = CloneUtil.deepClone(realmImport, RealmRepresentation.class, ignoredPropertiesForRealmImport);
+        RealmRepresentation realm = CloneUtil.deepClone(realmImport, RealmRepresentation.class,
+                ignoredPropertiesForRealmImport);
         realmRepository.create(realm);
 
-        // refresh the access token to update the scopes. See: https://github.com/adorsys/keycloak-config-cli/issues/339
+        // refresh the access token to update the scopes. See:
+        // https://github.com/adorsys/keycloak-config-cli/issues/339
         keycloakProvider.refreshToken();
 
         stateService.loadState(realmImport);
@@ -202,7 +206,8 @@ public class RealmImportService {
     private void updateRealm(RealmImport realmImport) {
         logger.debug("Updating realm '{}'...", realmImport.getRealm());
 
-        RealmRepresentation realm = CloneUtil.deepClone(realmImport, RealmRepresentation.class, ignoredPropertiesForRealmImport);
+        RealmRepresentation realm = CloneUtil.deepClone(realmImport, RealmRepresentation.class,
+                ignoredPropertiesForRealmImport);
 
         RealmRepresentation existingRealm = realmRepository.get(realmImport.getRealm());
 
@@ -223,8 +228,7 @@ public class RealmImportService {
         if (realmConfig.getOtpPolicyAlgorithm() != null) {
             otpPolicyImportService.updateOtpPolicy(
                     realmImport.getRealm(),
-                    realmConfig
-            );
+                    realmConfig);
         }
     }
 

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
@@ -1315,6 +1315,9 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
     @Test
     @Order(68)
     void shouldSetFirstBrokerLoginFlowAtRealmLevel() throws IOException {
+        // firstBrokerLoginFlow at realm level is only available in Keycloak 24+
+        assumeFalse(VersionUtil.lt(KEYCLOAK_VERSION, "24"));
+
         doImport("68_update_realm__set_first_broker_login_flow.json");
 
         RealmRepresentation realm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
@@ -871,9 +871,9 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(execution, hasSize(2));
 
         List<AuthenticationExecutionExportRepresentation> executionsId1 = execution.stream()
-          .filter((config) -> config.getAuthenticatorConfig() != null)
-          .filter((config) -> config.getAuthenticatorConfig().equals("config-1"))
-          .collect(Collectors.toList());
+                .filter((config) -> config.getAuthenticatorConfig() != null)
+                .filter((config) -> config.getAuthenticatorConfig().equals("config-1"))
+                .collect(Collectors.toList());
 
         assertThat(executionsId1, hasSize(1));
         assertThat(executionsId1.get(0).getAuthenticator(), is("identity-provider-redirector"));
@@ -881,9 +881,9 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(executionsId1.get(0).getRequirement(), is("ALTERNATIVE"));
 
         List<AuthenticationExecutionExportRepresentation> executionsId2 = execution.stream()
-          .filter((config) -> config.getAuthenticatorConfig() != null)
-          .filter((config) -> config.getAuthenticatorConfig().equals("config-2"))
-          .collect(Collectors.toList());
+                .filter((config) -> config.getAuthenticatorConfig() != null)
+                .filter((config) -> config.getAuthenticatorConfig().equals("config-2"))
+                .collect(Collectors.toList());
 
         assertThat(executionsId2, hasSize(1));
         assertThat(executionsId2.get(0).getAuthenticator(), is("identity-provider-redirector"));
@@ -1310,6 +1310,22 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(realm.getResetCredentialsFlow(), is("reset credentials"));
         assertThat(realm.getClientAuthenticationFlow(), is("clients"));
         assertThat(realm.getDockerAuthenticationFlow(), is("docker auth"));
+    }
+
+    @Test
+    @Order(68)
+    void shouldSetFirstBrokerLoginFlowAtRealmLevel() throws IOException {
+        doImport("68_update_realm__set_first_broker_login_flow.json");
+
+        RealmRepresentation realm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
+
+        assertThat(realm.getRealm(), is(REALM_NAME));
+        assertThat(realm.isEnabled(), is(true));
+
+        assertThat(realm.getFirstBrokerLoginFlow(), is("my realm first broker login"));
+
+        AuthenticationFlowRepresentation flow = getAuthenticationFlow(realm, "my realm first broker login");
+        assertThat(flow.getDescription(), is("My custom first broker login flow for realm"));
     }
 
     @Test

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
@@ -43,9 +43,10 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-@SuppressWarnings({"java:S5961", "java:S5976", "deprecation"})
+@SuppressWarnings({ "java:S5961", "java:S5976", "deprecation" })
 class ImportAuthenticationFlowsIT extends AbstractImportIT {
     private static final String REALM_NAME = "realmWithFlow";
 
@@ -74,7 +75,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         List<AuthenticationExecutionExportRepresentation> executions = flow.getAuthenticationExecutions();
         assertThat(executions, hasSize(1));
 
-        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(flow, "docker-http-basic-authenticator");
+        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(flow,
+                "docker-http-basic-authenticator");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("docker-http-basic-authenticator"));
         assertThat(execution.get(0).getRequirement(), is("DISABLED"));
@@ -234,9 +236,11 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
     void shouldFailWhenTryAddFlowWithDefectiveExecutionFlow() throws IOException {
         RealmImport foundImport = getFirstImport("05_try_to_update_realm__add_flow_with_defective_execution_flow.json");
 
-        InvalidImportException thrown = assertThrows(InvalidImportException.class, () -> realmImportService.doImport(foundImport));
+        InvalidImportException thrown = assertThrows(InvalidImportException.class,
+                () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), is("Execution property authenticator 'registration-page-form' can be only set if the sub-flow 'my registration form' type is 'form-flow'."));
+        assertThat(thrown.getMessage(), is(
+                "Execution property authenticator 'registration-page-form' can be only set if the sub-flow 'my registration form' type is 'form-flow'."));
     }
 
     @Test
@@ -288,41 +292,53 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
     @Test
     @Order(7)
     void shouldFailWhenTryToUpdateDefectiveFlowRequirementWithExecutionFlow() throws IOException {
-        RealmImport foundImport = getFirstImport("06_try_to_update_realm__change_requirement_in_defective_flow_with_execution_flow.json");
+        RealmImport foundImport = getFirstImport(
+                "06_try_to_update_realm__change_requirement_in_defective_flow_with_execution_flow.json");
 
-        InvalidImportException thrown = assertThrows(InvalidImportException.class, () -> realmImportService.doImport(foundImport));
+        InvalidImportException thrown = assertThrows(InvalidImportException.class,
+                () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), matchesPattern("Execution property authenticator 'registration-page-form' can be only set if the sub-flow 'my registration form' type is 'form-flow'."));
+        assertThat(thrown.getMessage(), matchesPattern(
+                "Execution property authenticator 'registration-page-form' can be only set if the sub-flow 'my registration form' type is 'form-flow'."));
     }
 
     @Test
     @Order(8)
     void shouldFailWhenTryToUpdateFlowRequirementWithExecutionFlowWithNotExistingExecution() throws IOException {
-        RealmImport foundImport = getFirstImport("07_try_to_update_realm__change_requirement_flow_with_execution_flow_with_not_existing_execution.json");
+        RealmImport foundImport = getFirstImport(
+                "07_try_to_update_realm__change_requirement_flow_with_execution_flow_with_not_existing_execution.json");
 
-        ImportProcessingException thrown = assertThrows(ImportProcessingException.class, () -> realmImportService.doImport(foundImport));
+        ImportProcessingException thrown = assertThrows(ImportProcessingException.class,
+                () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), matchesPattern("Cannot create execution 'not-existing-registration-user-creation' for non-top-level-flow 'my registration form' in realm 'realmWithFlow': .*"));
+        assertThat(thrown.getMessage(), matchesPattern(
+                "Cannot create execution 'not-existing-registration-user-creation' for non-top-level-flow 'my registration form' in realm 'realmWithFlow': .*"));
     }
 
     @Test
     @Order(9)
     void shouldFailWhenTryToUpdateFlowRequirementWithExecutionFlowWithDefectiveExecution() throws IOException {
-        RealmImport foundImport = getFirstImport("08_try_to_update_realm__change_requirement_flow_with_execution_flow_with_defective_execution.json");
+        RealmImport foundImport = getFirstImport(
+                "08_try_to_update_realm__change_requirement_flow_with_execution_flow_with_defective_execution.json");
 
-        ImportProcessingException thrown = assertThrows(ImportProcessingException.class, () -> realmImportService.doImport(foundImport));
+        ImportProcessingException thrown = assertThrows(ImportProcessingException.class,
+                () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), matchesPattern("Cannot update execution-flow 'registration-user-creation' for flow 'my registration form' in realm 'realmWithFlow': .*"));
+        assertThat(thrown.getMessage(), matchesPattern(
+                "Cannot update execution-flow 'registration-user-creation' for flow 'my registration form' in realm 'realmWithFlow': .*"));
     }
 
     @Test
     @Order(10)
     void shouldFailWhenTryToUpdateFlowRequirementWithDefectiveExecutionFlow() throws IOException {
-        RealmImport foundImport = getFirstImport("09_try_to_update_realm__change_requirement_flow_with_defective_execution_flow.json");
+        RealmImport foundImport = getFirstImport(
+                "09_try_to_update_realm__change_requirement_flow_with_defective_execution_flow.json");
 
-        ImportProcessingException thrown = assertThrows(ImportProcessingException.class, () -> realmImportService.doImport(foundImport));
+        ImportProcessingException thrown = assertThrows(ImportProcessingException.class,
+                () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), is("Cannot create execution-flow 'docker-http-basic-authenticator' for top-level-flow 'my auth flow' in realm 'realmWithFlow'"));
+        assertThat(thrown.getMessage(), is(
+                "Cannot create execution-flow 'docker-http-basic-authenticator' for top-level-flow 'my auth flow' in realm 'realmWithFlow'"));
     }
 
     @Test
@@ -412,7 +428,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(realm.getResetCredentialsFlow(), is("my reset credentials"));
 
         AuthenticationFlowRepresentation flow = getAuthenticationFlow(realm, "my reset credentials");
-        assertThat(flow.getDescription(), is("My reset credentials for a user if they forgot their password or something"));
+        assertThat(flow.getDescription(),
+                is("My reset credentials for a user if they forgot their password or something"));
     }
 
     @Test
@@ -427,7 +444,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(realm.getResetCredentialsFlow(), is("my reset credentials"));
 
         AuthenticationFlowRepresentation flow = getAuthenticationFlow(realm, "my reset credentials");
-        assertThat(flow.getDescription(), is("My changed reset credentials for a user if they forgot their password or something"));
+        assertThat(flow.getDescription(),
+                is("My changed reset credentials for a user if they forgot their password or something"));
     }
 
     @Test
@@ -649,7 +667,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         List<AuthenticationExecutionExportRepresentation> subFlowExecutions = subFlow.getAuthenticationExecutions();
         assertThat(subFlowExecutions, hasSize(2));
 
-        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(subFlow, "auth-username-password-form");
+        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(subFlow,
+                "auth-username-password-form");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("auth-username-password-form"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
@@ -690,11 +709,14 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
     @Order(27)
     @DisabledIfSystemProperty(named = "keycloak.version", matches = "import.files.locations*", disabledReason = "https://github.com/keycloak/keycloak/issues/10176")
     void shouldNotUpdateSubFlowWithPseudoId() throws IOException {
-        RealmImport foundImport = getFirstImport("27_update_realm__try-to-update-non-top-level-flow-with-pseudo-id.json");
+        RealmImport foundImport = getFirstImport(
+                "27_update_realm__try-to-update-non-top-level-flow-with-pseudo-id.json");
 
-        ImportProcessingException thrown = assertThrows(ImportProcessingException.class, () -> realmImportService.doImport(foundImport));
+        ImportProcessingException thrown = assertThrows(ImportProcessingException.class,
+                () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), matchesPattern("Cannot create execution-flow 'my registration form' for top-level-flow 'my registration' in realm 'realmWithFlow': .*"));
+        assertThat(thrown.getMessage(), matchesPattern(
+                "Cannot create execution-flow 'my registration form' for top-level-flow 'my registration' in realm 'realmWithFlow': .*"));
     }
 
     @Test
@@ -722,9 +744,11 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
     void shouldNotUpdateInvalidTopLevelFlow() throws IOException {
         RealmImport foundImport = getFirstImport("29_update_realm__try-to-update-invalid-top-level-flow.json");
 
-        ImportProcessingException thrown = assertThrows(ImportProcessingException.class, () -> realmImportService.doImport(foundImport));
+        ImportProcessingException thrown = assertThrows(ImportProcessingException.class,
+                () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), matchesPattern("Cannot create top-level-flow 'my auth flow' in realm 'realmWithFlow': .*"));
+        assertThat(thrown.getMessage(),
+                matchesPattern("Cannot create top-level-flow 'my auth flow' in realm 'realmWithFlow': .*"));
     }
 
     @Test
@@ -738,7 +762,6 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(flow.getDescription(), is("my browser based authentication"));
         assertThat(flow.isBuiltIn(), is(false));
         assertThat(flow.isTopLevel(), is(true));
-
 
         List<AuthenticationExecutionExportRepresentation> execution;
         execution = getExecutionFromFlow(flow, "identity-provider-redirector");
@@ -790,14 +813,13 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(flow.isBuiltIn(), is(false));
         assertThat(flow.isTopLevel(), is(true));
 
-
         List<AuthenticationExecutionExportRepresentation> execution;
         execution = getExecutionFromFlow(flow, "identity-provider-redirector");
         assertThat(execution, hasSize(3));
 
         List<AuthenticatorConfigRepresentation> authConfig;
         authConfig = getAuthenticatorConfig(realm, "id1");
-        int expectedAuthConfigSize = VersionUtil.lt(KEYCLOAK_VERSION, "26.1")? 2 : 1;
+        int expectedAuthConfigSize = VersionUtil.lt(KEYCLOAK_VERSION, "26.1") ? 2 : 1;
 
         assertThat(authConfig, hasSize(expectedAuthConfigSize));
         assertThat(authConfig.get(0).getAlias(), is("id1"));
@@ -825,14 +847,13 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(flow.isBuiltIn(), is(false));
         assertThat(flow.isTopLevel(), is(true));
 
-
         List<AuthenticationExecutionExportRepresentation> execution;
         execution = getExecutionFromFlow(flow, "identity-provider-redirector");
         assertThat(execution, hasSize(3));
 
         List<AuthenticatorConfigRepresentation> authConfig;
         authConfig = getAuthenticatorConfig(realm, "id1");
-        int expectedAuthConfigSize = VersionUtil.lt(KEYCLOAK_VERSION, "26.1")? 2 : 1;
+        int expectedAuthConfigSize = VersionUtil.lt(KEYCLOAK_VERSION, "26.1") ? 2 : 1;
 
         assertThat(authConfig, hasSize(expectedAuthConfigSize));
         assertThat(authConfig.get(0).getAlias(), is("id1"));
@@ -909,9 +930,11 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
     void shouldFailWhenTryingToUpdateBuiltInFlow() throws IOException {
         RealmImport foundImport = getFirstImport("40_update_realm__try-to-update-built-in-flow.json");
 
-        InvalidImportException thrown = assertThrows(InvalidImportException.class, () -> realmImportService.doImport(foundImport));
+        InvalidImportException thrown = assertThrows(InvalidImportException.class,
+                () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), is("Unable to update flow 'my auth flow with execution-flows' in realm 'realmWithFlow': Change built-in flag is not possible"));
+        assertThat(thrown.getMessage(), is(
+                "Unable to update flow 'my auth flow with execution-flows' in realm 'realmWithFlow': Change built-in flag is not possible"));
     }
 
     @Test
@@ -919,7 +942,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
     void shouldFailWhenTryingToUpdateWithNonExistingFlow() throws IOException {
         RealmImport foundImport = getFirstImport("41_update_realm__try-to-update-with-non-existing-flow.json");
 
-        ImportProcessingException thrown = assertThrows(ImportProcessingException.class, () -> realmImportService.doImport(foundImport));
+        ImportProcessingException thrown = assertThrows(ImportProcessingException.class,
+                () -> realmImportService.doImport(foundImport));
 
         assertThat(thrown.getMessage(), is("Non-toplevel flow not found: non existing sub flow"));
     }
@@ -936,7 +960,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(flow.isBuiltIn(), is(true));
         assertThat(flow.isTopLevel(), is(true));
 
-        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(flow, "http-basic-authenticator");
+        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(flow,
+                "http-basic-authenticator");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("http-basic-authenticator"));
         assertThat(execution.get(0).getRequirement(), is("CONDITIONAL"));
@@ -957,7 +982,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(flow.isBuiltIn(), is(true));
         assertThat(flow.isTopLevel(), is(false));
 
-        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(flow, "registration-recaptcha-action");
+        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(flow,
+                "registration-recaptcha-action");
         assertThat(execution.get(0).getAuthenticator(), is("registration-recaptcha-action"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
         assertThat(execution.get(0).getPriority(), is(60));
@@ -970,9 +996,11 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
     void shouldNotUpdateFlowWithBuiltInFalse() throws IOException {
         RealmImport foundImport = getFirstImport("44_update_realm__try-to-update-flow-set-builtin-false.json");
 
-        InvalidImportException thrown = assertThrows(InvalidImportException.class, () -> realmImportService.doImport(foundImport));
+        InvalidImportException thrown = assertThrows(InvalidImportException.class,
+                () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), is("Unable to recreate flow 'saml ecp' in realm 'realmWithFlow': Deletion or creation of built-in flows is not possible"));
+        assertThat(thrown.getMessage(), is(
+                "Unable to recreate flow 'saml ecp' in realm 'realmWithFlow': Deletion or creation of built-in flows is not possible"));
     }
 
     @Test
@@ -980,21 +1008,26 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
     void shouldNotUpdateFlowWithBuiltInTrue() throws IOException {
         RealmImport foundImport = getFirstImport("45_update_realm__try-to-update-flow-set-builtin-true.json");
 
-        InvalidImportException thrown = assertThrows(InvalidImportException.class, () -> realmImportService.doImport(foundImport));
+        InvalidImportException thrown = assertThrows(InvalidImportException.class,
+                () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), is("Unable to update flow 'my auth flow' in realm 'realmWithFlow': Change built-in flag is not possible"));
+        assertThat(thrown.getMessage(), is(
+                "Unable to update flow 'my auth flow' in realm 'realmWithFlow': Change built-in flag is not possible"));
     }
 
     @Test
     @Order(46)
     @DisabledIfSystemProperty(named = "keycloak.version", matches = "17.0.0", disabledReason = "https://github.com/keycloak/keycloak/issues/10176")
-    // NOTE: This test expects Keycloak/DB to fail on 256-character description (VARCHAR(255) constraint).
-    // Monitor CI runs: if this test starts passing unexpectedly, add @DisabledIfEnvironmentVariable
+    // NOTE: This test expects Keycloak/DB to fail on 256-character description
+    // (VARCHAR(255) constraint).
+    // Monitor CI runs: if this test starts passing unexpectedly, add
+    // @DisabledIfEnvironmentVariable
     // or adjust test setup to enforce strict VARCHAR(255) constraints.
     void shouldNotCreateBuiltInFlow() throws IOException {
         RealmImport foundImport = getFirstImport("46_update_realm__try-to-create-builtin-flow.json");
 
-        ImportProcessingException thrown = assertThrows(ImportProcessingException.class, () -> realmImportService.doImport(foundImport));
+        ImportProcessingException thrown = assertThrows(ImportProcessingException.class,
+                () -> realmImportService.doImport(foundImport));
 
         assertThat(thrown.getMessage(), is("Cannot update top-level-flow 'saml ecp' in realm 'realmWithFlow'."));
     }
@@ -1094,7 +1127,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         List<AuthenticationExecutionExportRepresentation> executions = flow.getAuthenticationExecutions();
         assertThat(executions, hasSize(1));
 
-        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(flow, "http-basic-authenticator");
+        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(flow,
+                "http-basic-authenticator");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("http-basic-authenticator"));
         assertThat(execution.get(0).getRequirement(), is("DISABLED"));
@@ -1156,7 +1190,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         List<AuthenticationExecutionExportRepresentation> executions = flow.getAuthenticationExecutions();
         assertThat(executions, hasSize(1));
 
-        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(flow, "http-basic-authenticator");
+        List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(flow,
+                "http-basic-authenticator");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("http-basic-authenticator"));
         assertThat(execution.get(0).getRequirement(), is("DISABLED"));
@@ -1208,7 +1243,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(realm.getRealm(), is(REALM_NAME));
         assertThat(realm.isEnabled(), is(true));
 
-        IdentityProviderRepresentation identityProviderRepresentation = identityProviderRepository.getAll(realm.getRealm()).stream()
+        IdentityProviderRepresentation identityProviderRepresentation = identityProviderRepository
+                .getAll(realm.getRealm()).stream()
                 .filter(idp -> Objects.equals(idp.getAlias(), "keycloak-oidc")).findFirst().orElse(null);
 
         assertThat(identityProviderRepresentation, is(not(nullValue())));
@@ -1228,7 +1264,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(realm.getRealm(), is(REALM_NAME));
         assertThat(realm.isEnabled(), is(true));
 
-        IdentityProviderRepresentation identityProviderRepresentation = identityProviderRepository.getAll(realm.getRealm()).stream()
+        IdentityProviderRepresentation identityProviderRepresentation = identityProviderRepository
+                .getAll(realm.getRealm()).stream()
                 .filter(idp -> Objects.equals(idp.getAlias(), "keycloak-oidc")).findFirst().orElse(null);
 
         assertThat(identityProviderRepresentation, is(not(nullValue())));
@@ -1243,11 +1280,12 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
     void shouldNotUpdateFlowWithAuthenticatorOnBasicFlow() throws IOException {
         RealmImport foundImport = getFirstImport("63_update-realm__try-to-set-authenticator-basic-flow.json");
 
-        InvalidImportException thrown = assertThrows(InvalidImportException.class, () -> realmImportService.doImport(foundImport));
+        InvalidImportException thrown = assertThrows(InvalidImportException.class,
+                () -> realmImportService.doImport(foundImport));
 
-        assertThat(thrown.getMessage(), is("Execution property authenticator 'registration-page-form' can be only set if the sub-flow 'JToken Conditional' type is 'form-flow'."));
+        assertThat(thrown.getMessage(), is(
+                "Execution property authenticator 'registration-page-form' can be only set if the sub-flow 'JToken Conditional' type is 'form-flow'."));
     }
-
 
     @Test
     @Order(66)
@@ -1271,14 +1309,15 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         doImport("66b_try_delete_referenced_authentication_flow.json");
         RealmRepresentation updatedRealm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
 
-        AuthenticationFlowRepresentation firstLoginFlow = getAuthenticationFlow(updatedRealm, "my custom first login flow");
+        AuthenticationFlowRepresentation firstLoginFlow = getAuthenticationFlow(updatedRealm,
+                "my custom first login flow");
         assertThat(firstLoginFlow, is(not(nullValue())));
         assertThat(firstLoginFlow.getAlias(), is("my custom first login flow"));
 
-        AuthenticationFlowRepresentation postLoginFlow = getAuthenticationFlow(updatedRealm, "my custom post login flow");
+        AuthenticationFlowRepresentation postLoginFlow = getAuthenticationFlow(updatedRealm,
+                "my custom post login flow");
         assertThat(postLoginFlow, is(not(nullValue())));
         assertThat(postLoginFlow.getAlias(), is("my custom post login flow"));
-
 
         IdentityProviderRepresentation updatedIdentityProvider = identityProviderRepository.getAll(REALM_NAME).stream()
                 .filter(idp -> "saml-with-custom-flow".equals(idp.getAlias()))
@@ -1325,7 +1364,15 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(realm.getRealm(), is(REALM_NAME));
         assertThat(realm.isEnabled(), is(true));
 
-        assertThat(realm.getFirstBrokerLoginFlow(), is("my realm first broker login"));
+        try {
+            String firstBrokerLoginFlow = (String) RealmRepresentation.class.getMethod("getFirstBrokerLoginFlow")
+                    .invoke(realm);
+            assertThat(firstBrokerLoginFlow, is("my realm first broker login"));
+        } catch (NoSuchMethodException e) {
+            fail("getFirstBrokerLoginFlow method not available - this should not happen when running on Keycloak 24+");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
 
         AuthenticationFlowRepresentation flow = getAuthenticationFlow(realm, "my realm first broker login");
         assertThat(flow.getDescription(), is("My custom first broker login flow for realm"));
@@ -1337,7 +1384,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         doImport("updated_custom_first-broker-login-flow.json");
 
         RealmRepresentation realm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
-        AuthenticationFlowRepresentation flow = getAuthenticationFlow(realm, "my-first-broker-login-handle-existing-account");
+        AuthenticationFlowRepresentation flow = getAuthenticationFlow(realm,
+                "my-first-broker-login-handle-existing-account");
 
         assertThat(realm.getRealm(), is(REALM_NAME));
         assertThat(realm.isEnabled(), is(true));
@@ -1345,7 +1393,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(flow.getAuthenticationExecutions().get(1).getRequirement(), is("DISABLED"));
     }
 
-    private List<AuthenticationExecutionExportRepresentation> getExecutionFromFlow(AuthenticationFlowRepresentation flow, String executionAuthenticator) {
+    private List<AuthenticationExecutionExportRepresentation> getExecutionFromFlow(
+            AuthenticationFlowRepresentation flow, String executionAuthenticator) {
         List<AuthenticationExecutionExportRepresentation> executions = flow.getAuthenticationExecutions();
 
         return executions.stream()
@@ -1353,7 +1402,8 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
                 .toList();
     }
 
-    private AuthenticationExecutionExportRepresentation getExecutionFlowFromFlow(AuthenticationFlowRepresentation flow, String subFlow) {
+    private AuthenticationExecutionExportRepresentation getExecutionFlowFromFlow(AuthenticationFlowRepresentation flow,
+            String subFlow) {
         List<AuthenticationExecutionExportRepresentation> executions = flow.getAuthenticationExecutions();
 
         return executions.stream()

--- a/src/test/resources/import-files/auth-flows/68_update_realm__set_first_broker_login_flow.json
+++ b/src/test/resources/import-files/auth-flows/68_update_realm__set_first_broker_login_flow.json
@@ -1,0 +1,65 @@
+{
+  "enabled": true,
+  "realm": "realmWithFlow",
+  "firstBrokerLoginFlow": "my realm first broker login",
+  "authenticationFlows": [
+    {
+      "alias": "my auth flow",
+      "description": "My auth flow for testing",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "requirement": "REQUIRED",
+          "priority": 1,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false,
+          "authenticatorFlow": false
+        },
+        {
+          "authenticator": "http-basic-authenticator",
+          "requirement": "DISABLED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false,
+          "authenticatorFlow": false
+        }
+      ]
+    },
+    {
+      "alias": "my realm first broker login",
+      "description": "My custom first broker login flow for realm",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-review-profile",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false,
+          "authenticatorFlow": false
+        },
+        {
+          "authenticator": "idp-create-user-if-unique",
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false,
+          "authenticatorFlow": false
+        },
+        {
+          "authenticator": "idp-auto-link",
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false,
+          "authenticatorFlow": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the HTTP 500 Internal Server Error (NullPointerException) that occurs when importing a realm configuration that defines a custom firstBrokerLoginFlow and its corresponding authentication flow in the same import. The issue was that firstBrokerLoginFlow was being sent to Keycloak before the referenced authentication flow was created.
The fix adds firstBrokerLoginFlow to the list of ignored properties during initial realm import, then explicitly sets it after authentication flows are created (similar to how browserFlow, registrationFlow, etc. are handled).

**Which issue this PR fixes**: fixes #1481 

**How this PR was tested**:

**Screenshots / logs** *(if relevant)*:

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] tests pass locally (`mvn test` or relevant subset)
- [x] added/updated tests for the changes (if applicable)
- [ ] documentation has been updated (if applicable)
- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
