### PR TITLE
Fix sub-flow execution priority being silently reset to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix Helm chart not being published to GitHub Pages on releases by publishing from tag pushes instead of main branch [#1356](https://github.com/adorsys/keycloak-config-cli/issues/1356)
 - Fix organization pagination conflict when importing realms with more than 10 organizations [#1493](https://github.com/adorsys/keycloak-config-cli/issues/1493)
 - Fix duplication of Identity Provider authorization resources (both `<uuid>` and `idp.resource.<uuid>`) when importing realm-management FGAP permissions [#1402](https://github.com/adorsys/keycloak-config-cli/issues/1402)
+- Preserve declared `priority` on executions inside sub-flows (was silently reset to 0) [#1539](https://github.com/adorsys/keycloak-config-cli/issues/1539)
 
 - Keycloak workflow API documentation differs from actual implementation [#1476](https://github.com/adorsys/keycloak-config-cli/pull/1476)
 - Support for Keycloak 26.5.5 to fix [#1303](https://github.com/adorsys/keycloak-config-cli/issues/1303)

--- a/src/main/java/de/adorsys/keycloak/config/repository/ExecutionFlowRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/ExecutionFlowRepository.java
@@ -134,7 +134,7 @@ public class ExecutionFlowRepository {
     public void createSubFlowExecution(
             String realmName,
             String subFlowAlias,
-            Map<String, String> executionData
+            Map<String, Object> executionData
     ) {
         logger.trace("Create flow-execution in realm '{}' and non-top-level-flow '{}'",
                 realmName, subFlowAlias);

--- a/src/main/java/de/adorsys/keycloak/config/repository/ExecutionFlowRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/ExecutionFlowRepository.java
@@ -131,6 +131,7 @@ public class ExecutionFlowRepository {
         }
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void createSubFlowExecution(
             String realmName,
             String subFlowAlias,
@@ -140,7 +141,9 @@ public class ExecutionFlowRepository {
                 realmName, subFlowAlias);
 
         AuthenticationManagementResource flowsResource = authenticationFlowRepository.getFlowResources(realmName);
-        flowsResource.addExecution(subFlowAlias, new HashMap<>(executionData));
+        // Raw Map: admin client declares Map<String, String> on Keycloak <25 and Map<String, Object> on >=25.
+        Map data = new HashMap<>(executionData);
+        flowsResource.addExecution(subFlowAlias, data);
 
         logger.trace("Created flow-execution in realm '{}' and non-top-level-flow '{}'",
                 realmName, subFlowAlias);

--- a/src/main/java/de/adorsys/keycloak/config/service/ExecutionFlowsImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/ExecutionFlowsImportService.java
@@ -23,10 +23,12 @@ package de.adorsys.keycloak.config.service;
 import de.adorsys.keycloak.config.exception.ImportProcessingException;
 import de.adorsys.keycloak.config.exception.InvalidImportException;
 import de.adorsys.keycloak.config.model.RealmImport;
+import de.adorsys.keycloak.config.provider.KeycloakProvider;
 import de.adorsys.keycloak.config.repository.AuthenticatorConfigRepository;
 import de.adorsys.keycloak.config.repository.ExecutionFlowRepository;
 import de.adorsys.keycloak.config.util.AuthenticationFlowUtil;
 import de.adorsys.keycloak.config.util.ResponseUtil;
+import de.adorsys.keycloak.config.util.VersionUtil;
 import org.keycloak.representations.idm.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,16 +51,21 @@ import jakarta.ws.rs.WebApplicationException;
 public class ExecutionFlowsImportService {
     private static final Logger logger = LoggerFactory.getLogger(ExecutionFlowsImportService.class);
 
+    private static final String SUB_FLOW_EXECUTION_PRIORITY_MIN_VERSION = "25";
+
     private final ExecutionFlowRepository executionFlowRepository;
     private final AuthenticatorConfigRepository authenticatorConfigRepository;
+    private final KeycloakProvider keycloakProvider;
 
     @Autowired
     public ExecutionFlowsImportService(
             ExecutionFlowRepository executionFlowRepository,
-            AuthenticatorConfigRepository authenticatorConfigRepository
+            AuthenticatorConfigRepository authenticatorConfigRepository,
+            KeycloakProvider keycloakProvider
     ) {
         this.executionFlowRepository = executionFlowRepository;
         this.authenticatorConfigRepository = authenticatorConfigRepository;
+        this.keycloakProvider = keycloakProvider;
     }
 
     public void createExecutionsAndExecutionFlows(
@@ -264,8 +271,14 @@ public class ExecutionFlowsImportService {
 
         HashMap<String, Object> execution = new HashMap<>();
         execution.put("provider", executionToImport.getAuthenticator());
-        if (executionToImport.getPriority() != null) {
-            execution.put("priority", executionToImport.getPriority());
+        // priority on sub-flow executions is honored only on Keycloak >= 25; older versions
+        // declare addExecutionToFlow as Map<String, String> and ignore the field.
+        // Integer local autoboxes the KC 22-24 primitive int getter so this compiles against both.
+        if (VersionUtil.ge(keycloakProvider.getKeycloakVersion(), SUB_FLOW_EXECUTION_PRIORITY_MIN_VERSION)) {
+            Integer priority = executionToImport.getPriority();
+            if (priority != null) {
+                execution.put("priority", priority);
+            }
         }
 
         try {

--- a/src/main/java/de/adorsys/keycloak/config/service/ExecutionFlowsImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/ExecutionFlowsImportService.java
@@ -262,8 +262,11 @@ public class ExecutionFlowsImportService {
         logger.debug("Create execution '{}' for non-top-level-flow '{}' in realm '{}'",
                 executionToImport.getAuthenticator(), subFlow.getAlias(), realmImport.getRealm());
 
-        HashMap<String, String> execution = new HashMap<>();
+        HashMap<String, Object> execution = new HashMap<>();
         execution.put("provider", executionToImport.getAuthenticator());
+        if (executionToImport.getPriority() != null) {
+            execution.put("priority", executionToImport.getPriority());
+        }
 
         try {
             executionFlowRepository.createSubFlowExecution(realmImport.getRealm(), subFlow.getAlias(), execution);

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
@@ -667,19 +667,22 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         List<AuthenticationExecutionExportRepresentation> subFlowExecutions = subFlow.getAuthenticationExecutions();
         assertThat(subFlowExecutions, hasSize(2));
 
+        // priority on sub-flow executions is honored only on Keycloak >= 25; older versions auto-assign sequential priorities (0, 1, ...)
+        boolean subFlowPriorityHonored = VersionUtil.ge(KEYCLOAK_VERSION, "25");
+
         List<AuthenticationExecutionExportRepresentation> execution = getExecutionFromFlow(subFlow,
                 "auth-username-password-form");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("auth-username-password-form"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
-        assertThat(execution.get(0).getPriority(), is(10));
+        assertThat(execution.get(0).getPriority(), is(subFlowPriorityHonored ? 10 : 0));
         assertThat(execution.get(0).isAutheticatorFlow(), is(false));
 
         execution = getExecutionFromFlow(subFlow, "auth-otp-form");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("auth-otp-form"));
         assertThat(execution.get(0).getRequirement(), is("CONDITIONAL"));
-        assertThat(execution.get(0).getPriority(), is(20));
+        assertThat(execution.get(0).getPriority(), is(subFlowPriorityHonored ? 20 : 1));
         assertThat(execution.get(0).isAutheticatorFlow(), is(false));
     }
 
@@ -912,13 +915,17 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(executionsId2.get(0).getRequirement(), is("ALTERNATIVE"));
 
         assertThat(executionsId2.get(0).getPriority(), greaterThan(executionsId1.get(0).getPriority()));
-        assertThat(executionsId1.get(0).getPriority(), is(1));
-        assertThat(executionsId2.get(0).getPriority(), is(2));
 
         List<AuthenticationExecutionExportRepresentation> httpBasicExecution = getExecutionFromFlow(subFlow,
                 "http-basic-authenticator");
         assertThat(httpBasicExecution, hasSize(1));
-        assertThat(httpBasicExecution.get(0).getPriority(), is(3));
+
+        // priority on sub-flow executions is honored only on Keycloak >= 25; older versions auto-assign 0, 1, 2 in declaration order
+        if (VersionUtil.ge(KEYCLOAK_VERSION, "25")) {
+            assertThat(executionsId1.get(0).getPriority(), is(1));
+            assertThat(executionsId2.get(0).getPriority(), is(2));
+            assertThat(httpBasicExecution.get(0).getPriority(), is(3));
+        }
 
         List<AuthenticatorConfigRepresentation> authConfig;
         authConfig = getAuthenticatorConfig(realm, "config-1");

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
@@ -672,14 +672,14 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("auth-username-password-form"));
         assertThat(execution.get(0).getRequirement(), is("REQUIRED"));
-        assertThat(execution.get(0).getPriority(), is(0));
+        assertThat(execution.get(0).getPriority(), is(10));
         assertThat(execution.get(0).isAutheticatorFlow(), is(false));
 
         execution = getExecutionFromFlow(subFlow, "auth-otp-form");
         assertThat(execution, hasSize(1));
         assertThat(execution.get(0).getAuthenticator(), is("auth-otp-form"));
         assertThat(execution.get(0).getRequirement(), is("CONDITIONAL"));
-        assertThat(execution.get(0).getPriority(), is(1));
+        assertThat(execution.get(0).getPriority(), is(20));
         assertThat(execution.get(0).isAutheticatorFlow(), is(false));
     }
 
@@ -912,6 +912,13 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(executionsId2.get(0).getRequirement(), is("ALTERNATIVE"));
 
         assertThat(executionsId2.get(0).getPriority(), greaterThan(executionsId1.get(0).getPriority()));
+        assertThat(executionsId1.get(0).getPriority(), is(1));
+        assertThat(executionsId2.get(0).getPriority(), is(2));
+
+        List<AuthenticationExecutionExportRepresentation> httpBasicExecution = getExecutionFromFlow(subFlow,
+                "http-basic-authenticator");
+        assertThat(httpBasicExecution, hasSize(1));
+        assertThat(httpBasicExecution.get(0).getPriority(), is(3));
 
         List<AuthenticatorConfigRepresentation> authConfig;
         authConfig = getAuthenticatorConfig(realm, "config-1");


### PR DESCRIPTION
**What this PR does / why we need it**:

Executions inside sub-flows (`topLevel: false`) were silently stored with `priority: 0`, regardless of the declared value in the imported realm. Top-level flow executions were unaffected because they go through a different code path that already sends `priority`.

The sub-flow create-payload (`ExecutionFlowsImportService#createExecutionForSubFlow` -> `ExecutionFlowRepository#createSubFlowExecution`) omitted the priority, so on the Keycloak side `addExecutionToFlow` fell into the `getNextPriority(parentFlow)` branch and auto-assigned a priority.

The fix passes the declared `priority` in the create-payload **on Keycloak >= 25**. Keycloak's server-side `addExecutionToFlow` only started accepting `priority` in 25 (the parameter type changed from `Map<String, String>` to `Map<String, Object>` and it now reads the `(Integer) data.get("priority")` value). On Keycloak < 25 the field is silently dropped server-side, so the version gate avoids sending a value that older servers don't honor (and would force a JSON-number-into-`Map<String,String>` deserialization).

**Which issue this PR fixes**: fixes #1539

**How this PR was tested**:

- `./mvnw test -Dtest='*Test'` — 334 unit tests pass
- `./mvnw test -Dtest=ImportAuthenticationFlowsIT -Dkeycloak.version=26.5.5` — all 54 flow ITs pass
- `./mvnw test -Dtest='ImportAuthenticationFlowsIT#shouldCreateMultipleSubFlowExecutionsWithSameAuthenticator+shouldAddTopLevelFlowWithExecutionFlow' -Dkeycloak.version=24.0.5 -Ppre-keycloak26` — targeted sub-flow ITs pass against a KC <25 server (priority is auto-assigned, version gate works)
- `shouldCreateMultipleSubFlowExecutionsWithSameAuthenticator` strengthened to assert exact priority values (1/2/3) on KC >= 25 — would have caught the bug on supported versions
- `shouldAddTopLevelFlowWithExecutionFlow` updated: previously asserted the buggy `priority is(0) / is(1)` for sub-flow executions declared as `10` / `20`; now asserts `is(10) / is(20)` on KC >= 25 and the legacy auto-assigned values on older

**Special notes for your reviewer**:

Compile and runtime compatibility across the full CI matrix (KC 21.x through 26.5.x) required three small accommodations:

1. **`Map<String, Object>` payload, raw `Map` at the admin-client call site** — the Keycloak admin client's `AuthenticationManagementResource#addExecution` is `Map<String, String>` on KC <25 and `Map<String, Object>` on KC >=25. A single `@SuppressWarnings({"rawtypes", "unchecked"})` on `createSubFlowExecution` lets the same source compile against either signature. This matches the `@SuppressWarnings` pattern already used elsewhere in the repo.
2. **`getPriority()` returns `int` on KC <25 and `Integer` on KC >=25** — assigning into a local `Integer priority` autoboxes the primitive on older clients, so the `priority != null` check compiles in both worlds.
3. **Version gate on the priority send** — `VersionUtil.ge(keycloakProvider.getKeycloakVersion(), "25")`. Older servers declare `Map<String, String>` and would have to coerce/deserialize an integer JSON value; gating sidesteps the risk and is a no-op for older versions where priority isn't honored anyway.

`KeycloakProvider` is now a constructor dependency on `ExecutionFlowsImportService` — the only behavior change beyond the priority send.

**PR Readiness Checklist**:

- [x] tests pass locally
- [x] added/updated tests for the changes
- [ ] documentation has been updated (no user-facing config changes; behavior fix only)
- [x] `CHANGELOG.md` updated