### PR TITLE
fix(authz): preserve full resource names for custom clients in FGAP V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add missing Keycloak baseline configurations for versions 21.1.2, 22.0.5, 26.1.0, 26.4.0, 26.5.5, and 26.5.7 [#1568](https://github.com/adorsys/keycloak-config-cli/issues/1568)
 
 ### Fixed
+- Fix regression under Keycloak FGAP V2 where authorization resource placeholders were eagerly stripped to bare UUIDs for custom clients (stripping is now safely scoped to internal admin clients only) [#1526](https://github.com/adorsys/keycloak-config-cli/issues/1526)
 - Fix `NullPointerException` during normalization when optional fields like `keycloakVersion` or client `protocol` are missing from the exported JSON [#1536](https://github.com/adorsys/keycloak-config-cli/issues/1536)
 - Fix Helm chart not being published to GitHub Pages on releases by publishing from tag pushes instead of main branch [#1356](https://github.com/adorsys/keycloak-config-cli/issues/1356)
 - Fix organization pagination conflict when importing realms with more than 10 organizations [#1493](https://github.com/adorsys/keycloak-config-cli/issues/1493)

--- a/src/main/java/de/adorsys/keycloak/config/service/ClientAuthorizationImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/ClientAuthorizationImportService.java
@@ -209,7 +209,16 @@ public class ClientAuthorizationImportService {
             );
         }
 
-        RealmManagementPermissionsResolver realmManagementPermissionsResolver = new RealmManagementPermissionsResolver(realmName);
+        boolean fgapV2Active = false;
+        try {
+            fgapV2Active = keycloakProvider.isFgapV2Active();
+        } catch (Exception e) {
+            logger.debug("Unable to determine FGAP V2 status in updateAuthorization: {}", e.getMessage());
+        }
+        boolean isAdminClient = REALM_MANAGEMENT_CLIENT_ID.equals(client.getClientId()) || ADMIN_PERMISSIONS_CLIENT_ID.equals(client.getClientId());
+        RealmManagementPermissionsResolver realmManagementPermissionsResolver = new RealmManagementPermissionsResolver(
+                realmName, fgapV2Active, isAdminClient
+        );
         if (REALM_MANAGEMENT_CLIENT_ID.equals(client.getClientId())) {
             realmManagementPermissionsResolver.createFineGrantedPermissions(authorizationSettingsToImport);
         }
@@ -855,9 +864,13 @@ public class ClientAuthorizationImportService {
 
         private final String realmName;
         private final Map<String, PermissionResolver> resolvers;
+        private final boolean isFgapV2;
+        private final boolean isAdminClient;
 
-        public RealmManagementPermissionsResolver(String realmName) {
+        public RealmManagementPermissionsResolver(String realmName, boolean isFgapV2, boolean isAdminClient) {
             this.realmName = realmName;
+            this.isFgapV2 = isFgapV2;
+            this.isAdminClient = isAdminClient;
             this.resolvers = new HashMap<>();
 
             resolvers.put("client", new ClientPermissionResolver(realmName, clientRepository));
@@ -928,16 +941,20 @@ public class ClientAuthorizationImportService {
 
         private String getSanitizedAuthzResourceName(String authzName) {
             PermissionTypeAndId typeAndId = PermissionTypeAndId.fromResourceName(authzName);
-            return getSanitizedAuthzName(authzName, typeAndId);
+            return getSanitizedAuthzName(authzName, typeAndId, true);
         }
 
 
-        private String getSanitizedAuthzName(String authzName, PermissionTypeAndId typeAndId) {
+        private String getSanitizedAuthzName(String authzName, PermissionTypeAndId typeAndId, boolean isResourceName) {
             if (typeAndId == null || !typeAndId.isPlaceholder()) {
                 return authzName;
             }
 
             String id = resolveObjectId(typeAndId, authzName);
+
+            if (isFgapV2 && isResourceName && isAdminClient && !"idp".equals(typeAndId.type)) {
+                return id;
+            }
 
             return authzName.replace(typeAndId.idOrPlaceholder, id);
         }

--- a/src/test/java/de/adorsys/keycloak/config/service/ClientAuthorizationImportServiceTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ClientAuthorizationImportServiceTest.java
@@ -719,8 +719,8 @@ class ClientAuthorizationImportServiceTest {
 
             // Then: V2 format (ID only) is used
             String resourcesConfig = verifyPolicyCreationAndGetResources();
-            assertEquals("[\"client.resource.abc-123-def\"]", resourcesConfig,
-                "V2 should use full resource string format");
+            assertEquals("[\"abc-123-def\"]", resourcesConfig,
+                "V2 should use ID only format");
         }
 
         @Test
@@ -764,8 +764,8 @@ class ClientAuthorizationImportServiceTest {
             String resourcesConfig = verifyPolicyCreationAndGetResources();
             assertTrue(resourcesConfig.contains("abc-123-def"), "First client ID should be present");
             assertTrue(resourcesConfig.contains("xyz-789-ghi"), "Second client ID should be present");
-            assertTrue(resourcesConfig.contains("client.resource"),
-                "V2 format should contain 'client.resource' prefix");
+            assertFalse(resourcesConfig.contains("client.resource"),
+                "V2 format should not contain 'client.resource' prefix");
         }
 
         @Test
@@ -783,8 +783,8 @@ class ClientAuthorizationImportServiceTest {
 
             // Then: Bare placeholder is transformed to ID only (using defaultResourceType to infer type)
             String resourcesConfig = verifyPolicyCreationAndGetResources();
-            assertEquals("[\"client.resource.abc-123-def\"]", resourcesConfig,
-                "Bare placeholder should be transformed to full resource name using defaultResourceType");
+            assertEquals("[\"abc-123-def\"]", resourcesConfig,
+                "Bare placeholder should be transformed to ID using defaultResourceType");
         }
 
         @Test


### PR DESCRIPTION
**What this PR does / why we need it**:

Provides proper control between fgap v1 and v2 
issue coming from bare ID

**Which issue this PR fixes** : fixes #1526 

**How this PR was tested**:

**Screenshots / logs** *(if relevant)*:

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] tests pass locally (`mvn test` or relevant subset)
- [x] added/updated tests for the changes (if applicable)
- [ ] documentation has been updated (if applicable)
- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
