### PR TITLE
docs: enhance LDAP user creation conflicts documentation

### DIFF
--- a/docs/config/import-settings.md
+++ b/docs/config/import-settings.md
@@ -35,14 +35,14 @@ java -jar keycloak-config-cli.jar \
 java -jar keycloak-config-cli.jar \
   --import.conflict-strategy=SKIP \
   --import.remove-default-roles=true \
-  --import.sync-user-federation-attributes=true
+  --import.behaviors.sync-user-federation=true
 ```
 
 | Setting | Description | Default | Options |
 |----------|-------------|---------|--------|
 | `--import.conflict-strategy` | How to handle conflicts | `SKIP` | `SKIP`, `OVERWRITE`, `MERGE` |
 | `--import.remove-default-roles` | Remove default roles on import | `false` | `true`, `false` |
-| `--import.sync-user-federation-attributes` | Sync federation attributes | `false` | `true`, `false` |
+| `--import.behaviors.sync-user-federation` | Sync federation providers on import | `false` | `true`, `false` |
 
 ### State Management
 

--- a/docs/config/ldap-user-creation-conflicts.md
+++ b/docs/config/ldap-user-creation-conflicts.md
@@ -70,10 +70,10 @@ When LDAP user federation is enabled:
 }
 ```
 
-step1
+#### Step 1: Configure LDAP Provider
 ![LDAP configuration in READ_ONLY mode with connection error](../static/images/ldap-images/ldap-config-readonly1.png)
 
-step2
+#### Step 2: Connection Test Failure Details
 ![LDAP configuration in READ_ONLY mode with connection error](../static/images/ldap-images/ldap-config-readonly2.png)
 
 *LDAP user federation configured with READ_ONLY edit mode. Connection test shows "Error when trying to connect to LDAP: 'UnknownHost'" because ldap.example.com doesn't exist. This demonstrates a common LDAP configuration issue.*
@@ -252,12 +252,10 @@ Error when trying to connect to LDAP: 'UnknownHost'
   ]
 }
 ```
-step1
-
+#### Step 1: Configure Local Admin and Service Accounts in Configuration
 ![Local service accounts created alongside LDAP federation](../static/images/ldap-images/ldap-service-account1.png)
 
-step2
-
+#### Step 2: View Successfully Created Local Users in keycloak-config-cli Output
 ![Local service accounts created alongside LDAP federation](../static/images/ldap-images/ldap-service-account2.png)
 
 *Local service accounts (keycloak-admin, api-service-account) successfully created in the realm. These accounts are stored locally in Keycloak and don't conflict with LDAP federation.*
@@ -388,8 +386,8 @@ Understanding edit modes is crucial:
 | Edit Mode | User Creation | User Updates | Use Case |
 |-----------|---------------|--------------|----------|
 | `READ_ONLY` | Not allowed | Not allowed | LDAP is authoritative, no Keycloak modifications |
-| `WRITABLE` | Via LDAP | Sync to LDAP | Keycloak can modify LDAP |
-| `UNSYNCED` | Local only | Local only | Users fetched from LDAP but changes stay local |
+| `WRITABLE` | Allowed (propagates to LDAP) | Allowed (syncs to LDAP) | Keycloak can create and modify users directly in LDAP |
+| `UNSYNCED` | Allowed (local only) | Allowed (local only) | Users imported from LDAP but subsequent changes stay local in Keycloak |
 
 ### READ_ONLY (Recommended for Most Cases)
 ```json
@@ -933,11 +931,13 @@ Or change to UNSYNCED mode:
 ---
 
 ## Configuration Options
-```bash
---import.behaviors.skip-attributes-for-federated-user=true
 
---import.behaviors.sync-user-federation=true
-```
+These behavior configuration options can be applied via command-line arguments, environment variables, or the `application.properties` configuration file:
+
+| CLI Option | Environment Variable | Property Key | Description | Default Value |
+|------------|----------------------|--------------|-------------|---------------|
+| `--import.behaviors.skip-attributes-for-federated-user` | `IMPORT_BEHAVIORS_SKIP_ATTRIBUTES_FOR_FEDERATED_USER` | `import.behaviors.skip-attributes-for-federated-user` | If set to `true`, keycloak-config-cli skips user attribute updates for federated users, preventing write errors in `READ_ONLY` or attribute-restricted LDAP setups. | `false` |
+| `--import.behaviors.sync-user-federation` | `IMPORT_BEHAVIORS_SYNC_USER_FEDERATION` | `import.behaviors.sync-user-federation` | If set to `true`, triggers a full synchronization of users from configured federation providers (like LDAP) during the import run. | `false` |
 
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhances the `ldap-user-creation-conflicts.md` documentation by fixing raw `step1`/`step2 `labels into proper markdown headings, expanding the edit mode descriptions in the reference table for clarity, and replacing the bare code-snippet Configuration Options section with a full table listing CLI flags, environment variables, property keys, descriptions, and default values. Also fixes an incorrect property name (`--import.sync-user-federation-attributes` → `--import.behaviors.sync-user-federation`) in import-settings.md.
**Which issue this PR fixes**: fixes #1585 

**How this PR was tested**:

**Screenshots / logs** *(if relevant)*:

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] tests pass locally (`mvn test` or relevant subset)
- [ ] added/updated tests for the changes (if applicable)
- [x] documentation has been updated (if applicable)
- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
