### PR TITLE
Release v6.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [6.5.1] - 2026-05-22
+
 ### Added
 - Add support for x509 client certificate authentication (mTLS) via `keycloak.tls.*` properties [#959](https://github.com/adorsys/keycloak-config-cli/issues/959)
 - Add missing Keycloak baseline configurations for versions 21.1.2, 22.0.5, 26.1.0, 26.4.0, 26.5.5, and 26.5.7 [#1568](https://github.com/adorsys/keycloak-config-cli/issues/1568)
@@ -965,14 +967,14 @@ A lot of import properties are added over the years. this major release of keycl
 <!-- @formatter:off -->
 
 
-[Unreleased]: https://github.com/adorsys/keycloak-config-cli/compare/v6.2.1...HEAD
 
-[Unreleased]: https://github.com/adorsys/keycloak-config-cli/compare/v6.5.0...HEAD
+
+[Unreleased]: https://github.com/adorsys/keycloak-config-cli/compare/v6.5.1...HEAD
+[6.5.1]: https://github.com/adorsys/keycloak-config-cli/compare/v6.5.0...v6.5.1
 [6.5.0]: https://github.com/adorsys/keycloak-config-cli/compare/v6.4.1...v6.5.0
 [6.4.1]: https://github.com/adorsys/keycloak-config-cli/compare/v6.4.0...v6.4.1
 [6.4.0]: https://github.com/adorsys/keycloak-config-cli/compare/v6.3.0...v6.4.0
 [6.3.0]: https://github.com/adorsys/keycloak-config-cli/compare/v6.2.1...v6.3.0
-
 [6.2.1]: https://github.com/adorsys/keycloak-config-cli/compare/v6.2.0...v6.2.1
 [6.2.0]: https://github.com/adorsys/keycloak-config-cli/compare/vFixed...v6.2.0
 [Fixed]: https://github.com/adorsys/keycloak-config-cli/compare/v6.1.11...vFixed

--- a/contrib/charts/keycloak-config-cli/Chart.yaml
+++ b/contrib/charts/keycloak-config-cli/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: keycloak-config-cli
 description: Import JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
 home: https://github.com/adorsys/keycloak-config-cli
-version: 6.5.1-SNAPSHOT
-appVersion: 6.5.1-SNAPSHOT
+version: 6.5.1
+appVersion: 6.5.1
 maintainers:
   - name: jkroepke
     email: joe@adorsys.de

--- a/contrib/charts/keycloak-config-cli/Chart.yaml
+++ b/contrib/charts/keycloak-config-cli/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: keycloak-config-cli
 description: Import JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
 home: https://github.com/adorsys/keycloak-config-cli
-version: 6.5.1
-appVersion: 6.5.1
+version: 6.5.2-SNAPSHOT
+appVersion: 6.5.2-SNAPSHOT
 maintainers:
   - name: jkroepke
     email: joe@adorsys.de

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>de.adorsys.keycloak</groupId>
     <artifactId>keycloak-config-cli</artifactId>
     <packaging>jar</packaging>
-    <version>6.5.1-SNAPSHOT</version>
+    <version>6.5.1</version>
 
     <name>keycloak-config-cli</name>
     <url>https://github.com/adorsys/keycloak-config-cli</url>
@@ -46,7 +46,7 @@
         <connection>scm:git:git://github.com/adorsys/keycloak-config-cli.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/keycloak-config-cli.git</developerConnection>
         <url>https://github.com/adorsys/keycloak-config-cli</url>
-        <tag>v6.5.0</tag>
+        <tag>v6.5.1</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>de.adorsys.keycloak</groupId>
     <artifactId>keycloak-config-cli</artifactId>
     <packaging>jar</packaging>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
 
     <name>keycloak-config-cli</name>
     <url>https://github.com/adorsys/keycloak-config-cli</url>
@@ -46,7 +46,7 @@
         <connection>scm:git:git://github.com/adorsys/keycloak-config-cli.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/keycloak-config-cli.git</developerConnection>
         <url>https://github.com/adorsys/keycloak-config-cli</url>
-        <tag>v6.5.1</tag>
+        <tag>v6.5.0</tag>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
## Summary

- Release keycloak-config-cli v6.5.1
- Apply Maven release plugin version changes
- Bump next development iteration to 6.5.2-SNAPSHOT

## Notes

after release v6.5.1.