### PR TITLE
Fix Keycloak FGAP version detection using wrong feature names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- Fix Keycloak FGAP version detection using wrong feature names [#1610](https://github.com/adorsys/keycloak-config-cli/issues/1610)
+
 ## [6.5.1] - 2026-05-22
 
 ### Added

--- a/src/main/java/de/adorsys/keycloak/config/provider/KeycloakProvider.java
+++ b/src/main/java/de/adorsys/keycloak/config/provider/KeycloakProvider.java
@@ -46,6 +46,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
 import java.util.function.Supplier;
 
 import jakarta.ws.rs.WebApplicationException;
@@ -140,7 +142,7 @@ public class KeycloakProvider implements AutoCloseable {
     }
 
     /**
-     * Definitive detection for Keycloak FGAP V2 (admin-fine-grained-authz:v2).
+     * Definitive detection for Keycloak FGAP V2 (ADMIN_FINE_GRAINED_AUTHZ_V2).
      * Uses server info profile features to determine whether FGAP V2 is active.
      * Result is cached in {@link #fgapV2Active}.
      * Returns false if detection fails.
@@ -178,29 +180,33 @@ public class KeycloakProvider implements AutoCloseable {
                 return fgapV2Active;
             }
 
-            java.util.List<String> disabled = profile.getDisabledFeatures();
-            java.util.List<String> preview = profile.getPreviewFeatures();
-            java.util.List<String> experimental = profile.getExperimentalFeatures();
+            List<String> disabled = profile.getDisabledFeatures();
+            List<String> preview = profile.getPreviewFeatures();
+            List<String> experimental = profile.getExperimentalFeatures();
+
+            // Using string names for backwards compability. See full list of feature names in:
+            // https://github.com/keycloak/keycloak/blob/main/common/src/main/java/org/keycloak/common/Profile.java
+            final String fgapV1 = "ADMIN_FINE_GRAINED_AUTHZ";
+            final String fgapV2 = "ADMIN_FINE_GRAINED_AUTHZ_V2";
 
             // If v2 is explicitly disabled, it's not active
-            if (disabled != null && disabled.contains("admin-fine-grained-authz:v2")) {
+            if (containsFeature(disabled, fgapV2)) {
                 fgapV2Active = false;
-                logger.debug("Detected admin-fine-grained-authz:v2 in disabled features => FGAP V2 not active");
+                logger.debug("Detected {} in disabled features => FGAP V2 not active", fgapV2);
                 return fgapV2Active;
             }
 
             // If v1 is present in preview/experimental, v1 is still in use -> V2 not active
-            if ((preview != null && preview.contains("admin-fine-grained-authz:v1"))
-                    || (experimental != null && experimental.contains("admin-fine-grained-authz:v1"))) {
+            if (containsFeature(preview, fgapV1) || containsFeature(experimental, fgapV1)) {
                 fgapV2Active = false;
                 logger.debug(
-                        "Detected admin-fine-grained-authz:v1 in preview/experimental features => FGAP V2 not active");
+                        "Detected {} in preview/experimental features => FGAP V2 not active", fgapV1);
                 return fgapV2Active;
             }
 
             // Otherwise, assume V2 is active (Keycloak 26.2+ defaults to V2)
             fgapV2Active = true;
-            logger.debug("Keycloak version {} with no V1/disabled V2 detected - FGAP V2 is active", keycloakVersion);
+            logger.debug("Keycloak version {} with no V1/disabled V2 detected => FGAP V2 is active", keycloakVersion);
             return fgapV2Active;
         } catch (Exception e) {
             logger.warn("Unable to detect FGAP V2 from server info: {}", e.getMessage());
@@ -417,5 +423,17 @@ public class KeycloakProvider implements AutoCloseable {
             objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             return objectMapper;
         }
+    }
+
+    /**
+     * Check if the given {@code names} collection isn't {@code null} and contains the given
+     * {@code feature}.
+     *
+     * @param names collection of feature names
+     * @param feature feature to find from the collection
+     * @return {@code true} if the collection contains the feature
+     */
+    private static boolean containsFeature(Collection<String> names, String feature) {
+        return names != null && names.contains(feature);
     }
 }

--- a/src/test/java/de/adorsys/keycloak/config/provider/KeycloakProviderTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/provider/KeycloakProviderTest.java
@@ -158,7 +158,7 @@ class KeycloakProviderTest {
                 org.keycloak.representations.info.SystemInfoRepresentation.class);
 
         when(systemInfo2.getVersion()).thenReturn("26.2.0");
-        when(profile2.getDisabledFeatures()).thenReturn(java.util.List.of("admin-fine-grained-authz:v2"));
+        when(profile2.getDisabledFeatures()).thenReturn(java.util.List.of("ADMIN_FINE_GRAINED_AUTHZ_V2"));
         when(serverInfo2.getSystemInfo()).thenReturn(systemInfo2);
         when(serverInfo2.getProfileInfo()).thenReturn(profile2);
         when(serverInfoResource2.getInfo()).thenReturn(serverInfo2);
@@ -183,7 +183,7 @@ class KeycloakProviderTest {
                 org.keycloak.representations.info.SystemInfoRepresentation.class);
 
         when(systemInfo3.getVersion()).thenReturn("26.2.0");
-        when(profile3.getPreviewFeatures()).thenReturn(java.util.List.of("admin-fine-grained-authz:v1"));
+        when(profile3.getPreviewFeatures()).thenReturn(java.util.List.of("ADMIN_FINE_GRAINED_AUTHZ"));
         when(serverInfo3.getSystemInfo()).thenReturn(systemInfo3);
         when(serverInfo3.getProfileInfo()).thenReturn(profile3);
         when(serverInfoResource3.getInfo()).thenReturn(serverInfo3);


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes linked issue.

**Which issue this PR fixes**: fixes #1610

**How this PR was tested**:

1. Starting Keycloak 26.6.2 with `--features=token-exchange:v1,admin-fine-grained-authz:v1` flag
2. Building custom version of the keycloak-config-cli
3. Importing realm.json with FGAPv1 resources in `realm-management`

**Screenshots / logs** *(if relevant)*:

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] tests pass locally (`mvn test` or relevant subset)
- [x] added/updated tests for the changes (if applicable)
- [ ] documentation has been updated (if applicable)
- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
