### PR TITLE
Add example groups to user creation JSON in user group update behavior documentation

### DIFF
--- a/docs/config/user-group-update-behavior.md
+++ b/docs/config/user-group-update-behavior.md
@@ -46,6 +46,14 @@ When a user exists and is updated:
 ```json
 {
   "realm": "master",
+  "groups": [
+    {
+      "name": "Developers"
+    },
+    {
+      "name": "Architects"
+    }
+  ],
   "users": [
     {
       "username": "john.doe",


### PR DESCRIPTION
**What this PR does / why we need it**:
Config import fails if groups do not exist. I defined the groups in the config, so import does not fail in case the groups do not exist 

Check the original documentation [here](https://adorsys.github.io/keycloak-config-cli/config/user-group-update-behavior/)

**Which issue this PR fixes**: fixes #1622 

**How this PR was tested**:

**Screenshots / logs** *(if relevant)*:

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] tests pass locally (`mvn test` or relevant subset)
- [ ] added/updated tests for the changes (if applicable)
- [x] documentation has been updated (if applicable)
- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
