### PR TITLE
fix(organizations): stop silently ignoring 'organizations' on Keycloak 26.4+

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,10 @@ jobs:
             KEYCLOAK_CLIENT_VERSION: 26.0.4
           - KEYCLOAK_VERSION: 26.5.5
             KEYCLOAK_CLIENT_VERSION: 26.0.8
+          - KEYCLOAK_VERSION: 26.6.2
+            KEYCLOAK_CLIENT_VERSION: 26.0.8
+          - KEYCLOAK_VERSION: 26.7.0
+            KEYCLOAK_CLIENT_VERSION: 26.0.8
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -64,6 +68,16 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ matrix.env.KEYCLOAK_VERSION }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-${{ matrix.env.KEYCLOAK_VERSION }}
+
+      # These steps overwrite COMPATIBILITY_PROFILE; the last matching one wins, so the broadest
+      # (highest) version threshold must come first and narrower thresholds override it below.
+      # A matrix entry that matches no step (Keycloak >= 26.6) builds with no compatibility
+      # profile, i.e. the full feature set. This is intentional: it makes a newer Keycloak entry
+      # fail loudly on a real incompatibility instead of silently dropping features.
+      - name: Adapt sources for Keycloak versions < 26.6.0 (skip passkey IT, server too old)
+        if: ${{ matrix.env.KEYCLOAK_VERSION < '26.6.0' }}
+        run: |
+          echo "COMPATIBILITY_PROFILE=-Ppre-keycloak26-6" >> $GITHUB_ENV
 
       - name: Adapt sources for Keycloak versions < 26.4.0
         if: ${{ matrix.env.KEYCLOAK_VERSION < '26.4.0' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix Keycloak FGAP version detection using wrong feature names [#1610](https://github.com/adorsys/keycloak-config-cli/issues/1610)
+- Fix `organizations` being silently ignored on Keycloak 26.4+. The `pre-keycloak26-6` Maven profile was `activeByDefault` and excluded the organization support classes (`OrganizationRepository`, `OrganizationImportService`) from compilation, so images built against Keycloak >= 26.4 shipped without organization support and dropped the `organizations` section with only a DEBUG log line. The organization classes now compile against the default admin client and are part of every build; compatibility profiles are activated explicitly per CI matrix entry (no more `activeByDefault`), and a warning is logged when an import declares organizations that cannot be applied [#1655](https://github.com/adorsys/keycloak-config-cli/issues/1655)
 
 ## [6.5.1] - 2026-05-22
 

--- a/pom.xml
+++ b/pom.xml
@@ -1101,23 +1101,30 @@ import org.keycloak.representations.userprofile.config.UPConfig;</token>
             </build>
         </profile>
         <profile>
+            <!--
+              Compatibility profile for Keycloak servers older than 26.6.
+
+              The organization classes (OrganizationRepository / OrganizationImportService)
+              compile against the default admin client (${keycloak.client.version}) and are
+              therefore part of every build; they must NOT be excluded here. This profile only
+              skips the passkey integration test, whose assertions require a Keycloak server
+              >= 26.6.
+
+              It must be activated explicitly (see .github/workflows/ci.yaml) and is deliberately
+              NOT activeByDefault: an activeByDefault profile is silently disabled as soon as any
+              other profile is activated (e.g. -Pcoverage or the default-keycloak-* profiles), so
+              relying on it to strip a shipped feature is a footgun - it dropped organization
+              support from published images while going unnoticed in CI.
+            -->
             <id>pre-keycloak26-6</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
-                            <excludes>
-                                <exclude>**/OrganizationRepository.java</exclude>
-                                <exclude>**/OrganizationImportService.java</exclude>
-                            </excludes>
                             <testExcludes>
                                 <exclude>**/ImportRealmWithPasskeyPropertiesIT.java</exclude>
-                                <exclude>**/ImportOrganizationsIT.java</exclude>
                             </testExcludes>
                         </configuration>
                     </plugin>

--- a/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
@@ -37,6 +37,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
 import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "IMPORT", matchIfMissing = true)
@@ -269,11 +271,29 @@ public class RealmImportService {
             Method doImport = clazz.getMethod("doImport", RealmImport.class);
             doImport.invoke(bean, realmImport);
         } catch (ClassNotFoundException e) {
-            logger.debug("OrganizationImportService not available on classpath.");
+            warnIfOrganizationsDeclared(realmImport, "is not available on the classpath "
+                    + "(this keycloak-config-cli build was compiled without organization support)");
         } catch (NoSuchBeanDefinitionException e) {
-            logger.debug("OrganizationImportService bean not registered.");
+            warnIfOrganizationsDeclared(realmImport, "is not registered "
+                    + "(the target Keycloak version does not support organizations)");
         } catch (ReflectiveOperationException e) {
             logger.warn("Failed to invoke OrganizationImportService: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Logs at WARN level when a realm import actually declares organizations but the organization
+     * import service could not be invoked, so a silently dropped feature becomes visible. When no
+     * organizations are declared, the (expected) absence is only logged at DEBUG level.
+     */
+    private void warnIfOrganizationsDeclared(RealmImport realmImport, String reason) {
+        List<Map<String, Object>> organizations = realmImport.getOrganizationsRaw();
+        if (organizations != null && !organizations.isEmpty()) {
+            logger.warn("Realm '{}' declares {} organization(s), but the organization import service {}. "
+                            + "The 'organizations' section was ignored.",
+                    realmImport.getRealm(), organizations.size(), reason);
+        } else {
+            logger.debug("OrganizationImportService {}.", reason);
         }
     }
 }


### PR DESCRIPTION


**What this PR does / why we need it**:

`keycloak-config-cli` images built against Keycloak 26.4+ silently ignored the `organizations` section of a realm import.

Root cause: the `pre-keycloak26-6` Maven profile was `<activeByDefault>true</activeByDefault>` and excluded `OrganizationRepository` and `OrganizationImportService` from compilation. Maven disables an `activeByDefault` profile as soon as *any* other profile is activated (`-Pcoverage` in the `build` job, or the property-activated `default-keycloak-*` profiles), so whether organization support shipped depended on unrelated build flags. The released `6.5.1` images for Keycloak ≥ 26.4 shipped without the classes, and at runtime `RealmImportService` invokes them reflectively and logged their absence only at `DEBUG` — so the `organizations` block was dropped with no error and exit code 0.

The organization classes compile unchanged against the default admin client (`26.0.8`), so no exclusion was ever necessary for Keycloak ≥ 26.4. This PR:

- Removes `activeByDefault` and the organization-class exclusions from `pre-keycloak26-6`; the organization classes are now part of every build. The profile now only skips the passkey IT (which requires a server ≥ 26.6).
- Makes compatibility profiles explicit per CI matrix entry: `pre-keycloak26-6` is activated for `KEYCLOAK_VERSION < 26.6.0`. A newer Keycloak entry matches no profile and builds the full feature set, so a real incompatibility fails loudly instead of silently dropping a feature.
- Adds CI matrix entries for Keycloak `26.6.2` and `26.7.0` (client `26.0.8`) so images are built and tested against the current releases.
- Re-enables `ImportOrganizationsIT` for builds that include the code.
- Logs at `WARN` (instead of `DEBUG`) in `RealmImportService` when an import actually declares `organizations` but the service is unavailable, so a dropped feature becomes visible.

**Which issue this PR fixes**
fixes #1655,
fixes #1652,
fixes #1493,

**How this PR was tested**:

- `./mvnw checkstyle:check` → 0 violations.
- Full `./mvnw verify -Pcoverage` on **Java 21** for the new `26.6.2` (no compatibility profile) and `26.5.5` (`-Ppre-keycloak26-6`) matrix entries → `BUILD SUCCESS`, 338 unit tests pass, and `unzip -l target/keycloak-config-cli.jar` confirms `OrganizationRepository.class` and `OrganizationImportService.class` are present. The `26.5.5` build correctly omits the passkey IT from compilation.
- End-to-end against real Keycloak Testcontainers (admin client `26.0.8`, Java 21): `ImportOrganizationsIT` and `ImportRealmWithPasskeyPropertiesIT` pass against both **26.6.2** and **26.7.0**.
- Reproduced the pre-fix landmine: `./mvnw verify -Dkeycloak.version=26.5.5 -Dkeycloak.client.version=26.0.8` (no other profile) fails to compile on current `main`, because `pre-keycloak26-6` excluded the org main classes but not the tests that depend on them.

**Screenshots / logs** *(if relevant)*:

Integration tests against Keycloak 26.7.0 (admin client 26.0.8):

    [INFO] Running de.adorsys.keycloak.config.service.ImportOrganizationsIT
    [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- in ...ImportOrganizationsIT
    [INFO] Running de.adorsys.keycloak.config.service.ImportRealmWithPasskeyPropertiesIT
    [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0 -- in ...ImportRealmWithPasskeyPropertiesIT

**Special notes for your reviewer**:

- The core issue is the `activeByDefault` interaction: it is silently disabled whenever another profile is active, so `-Pcoverage` in the `build` job happened to include the classes in CI while released images (built the same way) still lacked them. Making activation explicit removes that footgun.
- No change was needed to `OrganizationRepository` — the current paginated implementation compiles as-is against admin client `26.0.8`. This is purely build wiring + observability.
- `maven-failsafe-plugin` is only declared in `<pluginManagement>`, so `*IT` tests do not run during `mvn verify`; I exercised the integration tests by invoking the failsafe goal directly. Left unchanged as it is out of scope for this fix.
- The new `WARN` branch in `RealmImportService` is not covered by a dedicated unit test (the functional change is covered by the re-enabled `ImportOrganizationsIT`). Happy to add one if you'd prefer.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] tests pass locally (`mvn test` or relevant subset)
- [x] added/updated tests for the changes (if applicable) — re-enabled `ImportOrganizationsIT` (see reviewer note re: the WARN branch)
- [x] documentation has been updated (if applicable) — `CHANGELOG.md` updated; README/DOCUMENTATION are version-agnostic
- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR