### PR TITLE
fix(roles): ignore server-generated ids when comparing roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix Keycloak FGAP version detection using wrong feature names [#1610](https://github.com/adorsys/keycloak-config-cli/issues/1610)
+- Fix role change-detection issuing spurious updates on cross-instance imports by ignoring server-generated `id` and `containerId` when comparing realm and client roles (previously caused HTTP 403 failures on `admin`, `create-realm`, and `realm-management` roles on Keycloak 26.6.4+)
 
 ## [6.5.1] - 2026-05-22
 

--- a/src/main/java/de/adorsys/keycloak/config/service/RoleImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RoleImportService.java
@@ -30,6 +30,7 @@ import de.adorsys.keycloak.config.service.state.StateService;
 import de.adorsys.keycloak.config.util.CloneUtil;
 import de.adorsys.keycloak.config.util.KeycloakUtil;
 import de.adorsys.keycloak.config.util.ParallelUtil;
+import org.apache.commons.lang3.ArrayUtils;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
 import org.slf4j.Logger;
@@ -52,6 +53,7 @@ public class RoleImportService {
     private static final String[] propertiesWithDependencies = new String[]{
             "composites",
     };
+    private static final String[] propertiesToIgnoreOnUpdate = ArrayUtils.addAll(propertiesWithDependencies, "id", "containerId");
 
     private final RealmRoleCompositeImportService realmRoleCompositeImport;
     private final ClientRoleCompositeImportService clientRoleCompositeImport;
@@ -213,12 +215,12 @@ public class RoleImportService {
             RoleRepresentation roleToImport
     ) {
         String roleName = roleToImport.getName();
-        RoleRepresentation patchedRole = CloneUtil.patch(existingRole, roleToImport, propertiesWithDependencies);
+        RoleRepresentation patchedRole = CloneUtil.patch(existingRole, roleToImport, propertiesToIgnoreOnUpdate);
         if (roleToImport.getAttributes() != null) {
             patchedRole.setAttributes(roleToImport.getAttributes());
         }
 
-        if (!CloneUtil.deepEquals(existingRole, patchedRole)) {
+        if (!CloneUtil.deepEquals(existingRole, patchedRole, propertiesToIgnoreOnUpdate)) {
             logger.debug("Update realm-level role '{}' in realm '{}'", roleName, realmName);
             roleRepository.updateRealmRole(realmName, patchedRole);
         } else {
@@ -232,10 +234,10 @@ public class RoleImportService {
             RoleRepresentation existingRole,
             RoleRepresentation roleToImport
     ) {
-        RoleRepresentation patchedRole = CloneUtil.patch(existingRole, roleToImport, propertiesWithDependencies);
+        RoleRepresentation patchedRole = CloneUtil.patch(existingRole, roleToImport, propertiesToIgnoreOnUpdate);
         String roleName = existingRole.getName();
 
-        if (CloneUtil.deepEquals(existingRole, patchedRole)) {
+        if (CloneUtil.deepEquals(existingRole, patchedRole, propertiesToIgnoreOnUpdate)) {
             logger.debug("No need to update client-level role '{}' for client '{}' in realm '{}'", roleName, clientId, realmName);
         } else {
             logger.debug("Update client-level role '{}' for client '{}' in realm '{}'", roleName, clientId, realmName);

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportRolesIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportRolesIT.java
@@ -1047,6 +1047,76 @@ class ImportRolesIT extends AbstractImportIT {
         assertThat(composites.getRealm(), is(nullValue()));
     }
 
+    @Test
+    @Order(80)
+    void shouldNotChangeRolesWhenOnlyRoleIdentifiersDiffer() throws IOException {
+        // Given: a realm whose roles were created by a previous import
+        doImport("80.1_create_realm_with_roles_for_id_mismatch.json");
+
+        String realmName = "realmWithRoles80";
+        RealmRepresentation createdRealm = keycloakProvider.getInstance().realm(realmName).partialExport(true, true);
+
+        RoleRepresentation createdRealmRole = keycloakRepository.getRealmRole(createdRealm, "my_realm_role_80");
+        RoleRepresentation createdClientRole = keycloakRepository.getClientRole(createdRealm, "moped-client", "my_client_role_80");
+
+        String realmRoleId = createdRealmRole.getId();
+        String realmRoleContainerId = createdRealmRole.getContainerId();
+        String clientRoleId = createdClientRole.getId();
+        String clientRoleContainerId = createdClientRole.getContainerId();
+
+        // When: the same content is imported again, but carrying identifiers of a foreign instance
+        doImport("80.2_update_realm_with_mismatching_role_ids.json");
+
+        // Then: no role was changed - identifiers of this instance are untouched, content is unchanged
+        RealmRepresentation realm = keycloakProvider.getInstance().realm(realmName).partialExport(true, true);
+
+        RoleRepresentation realmRole = keycloakRepository.getRealmRole(realm, "my_realm_role_80");
+        assertThat(realmRole.getId(), is(realmRoleId));
+        assertThat(realmRole.getContainerId(), is(realmRoleContainerId));
+        assertThat(realmRole.getDescription(), is("My realm role"));
+
+        RoleRepresentation clientRole = keycloakRepository.getClientRole(realm, "moped-client", "my_client_role_80");
+        assertThat(clientRole.getId(), is(clientRoleId));
+        assertThat(clientRole.getContainerId(), is(clientRoleContainerId));
+        assertThat(clientRole.getDescription(), is("My moped-client role"));
+    }
+
+    @Test
+    @Order(81)
+    void shouldStillApplyRealContentChangeWhenRoleIdentifiersDiffer() throws IOException {
+        // Given: the roles of the realm as left by the previous import
+        String realmName = "realmWithRoles80";
+        RealmRepresentation realmBefore = keycloakProvider.getInstance().realm(realmName).partialExport(true, true);
+
+        String realmRoleId = keycloakRepository.getRealmRole(realmBefore, "my_realm_role_80").getId();
+        String clientRoleId = keycloakRepository.getClientRole(realmBefore, "moped-client", "my_client_role_80").getId();
+
+        // When: an import with foreign identifiers AND changed descriptions is applied
+        doImport("80.3_update_realm_with_mismatching_role_ids_and_changed_content.json");
+
+        // Then: the content change is applied, while this instance keeps its own role identifiers
+        RealmRepresentation realm = keycloakProvider.getInstance().realm(realmName).partialExport(true, true);
+
+        RoleRepresentation realmRole = keycloakRepository.getRealmRole(realm, "my_realm_role_80");
+        assertThat(realmRole.getDescription(), is("My changed realm role"));
+        assertThat(realmRole.getId(), is(realmRoleId));
+
+        RoleRepresentation clientRole = keycloakRepository.getClientRole(realm, "moped-client", "my_client_role_80");
+        assertThat(clientRole.getDescription(), is("My changed moped-client role"));
+        assertThat(clientRole.getId(), is(clientRoleId));
+    }
+
+    @Test
+    @Order(82)
+    void shouldImportProtectedRolesWithMatchingContentWithoutUpdate() {
+        // Given: an import containing protected roles (admin, create-realm, realm-management client roles)
+        //        whose content matches the target, but whose identifiers come from a foreign instance
+
+        // When: the import runs
+        // Then: it completes - a spurious update of a protected role would be rejected with HTTP 403
+        assertDoesNotThrow(() -> doImport("82_import_realm_with_protected_roles.json"));
+    }
+
     @SuppressWarnings("SpringJavaAutowiredMembersInspection")
     @Nested
     @Order(60)

--- a/src/test/java/de/adorsys/keycloak/config/service/RoleImportServiceTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/RoleImportServiceTest.java
@@ -1,0 +1,336 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2025 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.service;
+
+import de.adorsys.keycloak.config.model.RealmImport;
+import de.adorsys.keycloak.config.properties.ImportConfigProperties;
+import de.adorsys.keycloak.config.repository.RoleRepository;
+import de.adorsys.keycloak.config.service.rolecomposites.client.ClientRoleCompositeImportService;
+import de.adorsys.keycloak.config.service.rolecomposites.realm.RealmRoleCompositeImportService;
+import de.adorsys.keycloak.config.service.state.StateService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.RolesRepresentation;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static de.adorsys.keycloak.config.properties.ImportConfigProperties.ImportManagedProperties.ImportManagedPropertiesValues;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Change-detection tests for {@link RoleImportService}.
+ *
+ * <p>Server-generated identifiers ({@code id} of the role itself and {@code containerId} of its owning
+ * realm/client) must never be interpreted as a content change: an import file typically carries the
+ * identifiers of the instance it was exported from, which never match the target instance.
+ */
+class RoleImportServiceTest {
+
+    private static final String REALM_NAME = "realmWithRoles";
+    private static final String CLIENT_ID = "moped-client";
+    private static final String REALM_ROLE_NAME = "my_realm_role";
+    private static final String CLIENT_ROLE_NAME = "my_client_role";
+
+    private static final String EXISTING_ROLE_ID = "1eb9dd3b-0000-0000-0000-0000000000aa";
+    private static final String EXISTING_CONTAINER_ID = "1eb9dd3b-0000-0000-0000-0000000000bb";
+    private static final String IMPORTED_ROLE_ID = "9999ffff-0000-0000-0000-0000000000aa";
+    private static final String IMPORTED_CONTAINER_ID = "9999ffff-0000-0000-0000-0000000000bb";
+
+    private static final String DESCRIPTION = "My role";
+    private static final String CHANGED_DESCRIPTION = "My changed role";
+    private static final Map<String, List<String>> ATTRIBUTES = Map.of("my attribute", List.of("my value"));
+    private static final Map<String, List<String>> CHANGED_ATTRIBUTES = Map.of("my attribute", List.of("my changed value"));
+
+    private RoleRepository roleRepository;
+    private ImportConfigProperties importConfigProperties;
+
+    private RoleImportService service;
+
+    @BeforeEach
+    void setUp() {
+        roleRepository = mock(RoleRepository.class);
+        importConfigProperties = mock(ImportConfigProperties.class);
+        final ImportConfigProperties.ImportManagedProperties managed =
+                mock(ImportConfigProperties.ImportManagedProperties.class);
+
+        when(importConfigProperties.getManaged()).thenReturn(managed);
+        when(managed.getRole()).thenReturn(ImportManagedPropertiesValues.NO_DELETE);
+        when(importConfigProperties.isParallel()).thenReturn(false);
+
+        service = new RoleImportService(
+                mock(RealmRoleCompositeImportService.class),
+                mock(ClientRoleCompositeImportService.class),
+                roleRepository,
+                importConfigProperties,
+                mock(StateService.class)
+        );
+    }
+
+    @Nested
+    class RealmRoles {
+
+        @Test
+        void doImport_shouldNotUpdateRealmRoleWhenOnlyRoleIdDiffers() {
+            // Given: an existing realm role and an identical imported role with a different role id
+            final RoleRepresentation existingRole = aRealmRole(EXISTING_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport = aRealmRole(IMPORTED_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            when(roleRepository.getRealmRoles(REALM_NAME)).thenReturn(List.of(existingRole));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithRealmRoles(roleToImport));
+
+            // Then: the differing role id alone is not a change, so no update is sent to Keycloak
+            verify(roleRepository, never()).updateRealmRole(anyString(), any());
+        }
+
+        @Test
+        void doImport_shouldNotUpdateRealmRoleWhenOnlyContainerIdDiffers() {
+            // Given: an existing realm role and an identical imported role with a different container id
+            final RoleRepresentation existingRole = aRealmRole(EXISTING_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport = aRealmRole(EXISTING_ROLE_ID, IMPORTED_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            when(roleRepository.getRealmRoles(REALM_NAME)).thenReturn(List.of(existingRole));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithRealmRoles(roleToImport));
+
+            // Then: the differing container id alone is not a change, so no update is sent to Keycloak
+            verify(roleRepository, never()).updateRealmRole(anyString(), any());
+        }
+
+        @Test
+        void doImport_shouldNotUpdateRealmRoleWhenBothIdentifiersDifferAndContentIsIdentical() {
+            // Given: an existing realm role and an imported role differing only in both identifiers
+            final RoleRepresentation existingRole = aRealmRole(EXISTING_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport = aRealmRole(IMPORTED_ROLE_ID, IMPORTED_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            when(roleRepository.getRealmRoles(REALM_NAME)).thenReturn(List.of(existingRole));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithRealmRoles(roleToImport));
+
+            // Then: identifier-only differences never trigger an update
+            verify(roleRepository, never()).updateRealmRole(anyString(), any());
+        }
+
+        @Test
+        void doImport_shouldNotUpdateRealmRoleWhenImportCarriesNoIdentifiers() {
+            // Given: an existing realm role and an imported role without any identifiers (config-as-code case)
+            final RoleRepresentation existingRole = aRealmRole(EXISTING_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport = aRealmRole(null, null, DESCRIPTION, ATTRIBUTES);
+            when(roleRepository.getRealmRoles(REALM_NAME)).thenReturn(List.of(existingRole));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithRealmRoles(roleToImport));
+
+            // Then: absent identifiers are not a difference, so no update is sent to Keycloak
+            verify(roleRepository, never()).updateRealmRole(anyString(), any());
+        }
+
+        @Test
+        void doImport_shouldNotUpdateRealmRoleWhenExistingRoleCarriesNoIdentifiers() {
+            // Given: an existing realm role without identifiers and an imported role carrying identifiers
+            final RoleRepresentation existingRole = aRealmRole(null, null, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport = aRealmRole(IMPORTED_ROLE_ID, IMPORTED_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            when(roleRepository.getRealmRoles(REALM_NAME)).thenReturn(List.of(existingRole));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithRealmRoles(roleToImport));
+
+            // Then: identifiers present only on the import side are not a difference either
+            verify(roleRepository, never()).updateRealmRole(anyString(), any());
+        }
+
+        @Test
+        void doImport_shouldUpdateRealmRoleWhenIdentifiersAndContentDiffer() {
+            // Given: an existing realm role and an imported role differing in identifiers AND content
+            final RoleRepresentation existingRole = aRealmRole(EXISTING_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport =
+                    aRealmRole(IMPORTED_ROLE_ID, IMPORTED_CONTAINER_ID, CHANGED_DESCRIPTION, CHANGED_ATTRIBUTES);
+            when(roleRepository.getRealmRoles(REALM_NAME)).thenReturn(List.of(existingRole));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithRealmRoles(roleToImport));
+
+            // Then: the genuine content change is applied to the existing role, keeping its own identifiers
+            final ArgumentCaptor<RoleRepresentation> captor = ArgumentCaptor.forClass(RoleRepresentation.class);
+            verify(roleRepository).updateRealmRole(anyString(), captor.capture());
+
+            final RoleRepresentation updatedRole = captor.getValue();
+            assertEquals(REALM_ROLE_NAME, updatedRole.getName(), "the existing role must be the update target");
+            assertEquals(EXISTING_ROLE_ID, updatedRole.getId(), "the target instance role id must be preserved");
+            assertEquals(EXISTING_CONTAINER_ID, updatedRole.getContainerId(), "the target instance container id must be preserved");
+            assertEquals(CHANGED_DESCRIPTION, updatedRole.getDescription(), "the new description must be applied");
+            assertEquals(CHANGED_ATTRIBUTES, updatedRole.getAttributes(), "the new attributes must be applied");
+        }
+    }
+
+    @Nested
+    class ClientRoles {
+
+        @Test
+        void doImport_shouldNotUpdateClientRoleWhenOnlyRoleIdDiffers() {
+            // Given: an existing client role and an identical imported role with a different role id
+            final RoleRepresentation existingRole = aClientRole(EXISTING_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport = aClientRole(IMPORTED_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            when(roleRepository.getClientRoles(REALM_NAME)).thenReturn(Map.of(CLIENT_ID, List.of(existingRole)));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithClientRoles(roleToImport));
+
+            // Then: the differing role id alone is not a change, so no update is sent to Keycloak
+            verify(roleRepository, never()).updateClientRole(anyString(), anyString(), any());
+        }
+
+        @Test
+        void doImport_shouldNotUpdateClientRoleWhenOnlyContainerIdDiffers() {
+            // Given: an existing client role and an identical imported role with a different container id
+            final RoleRepresentation existingRole = aClientRole(EXISTING_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport = aClientRole(EXISTING_ROLE_ID, IMPORTED_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            when(roleRepository.getClientRoles(REALM_NAME)).thenReturn(Map.of(CLIENT_ID, List.of(existingRole)));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithClientRoles(roleToImport));
+
+            // Then: the differing container id alone is not a change, so no update is sent to Keycloak
+            verify(roleRepository, never()).updateClientRole(anyString(), anyString(), any());
+        }
+
+        @Test
+        void doImport_shouldNotUpdateClientRoleWhenBothIdentifiersDifferAndContentIsIdentical() {
+            // Given: an existing client role and an imported role differing only in both identifiers
+            final RoleRepresentation existingRole = aClientRole(EXISTING_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport = aClientRole(IMPORTED_ROLE_ID, IMPORTED_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            when(roleRepository.getClientRoles(REALM_NAME)).thenReturn(Map.of(CLIENT_ID, List.of(existingRole)));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithClientRoles(roleToImport));
+
+            // Then: identifier-only differences never trigger an update
+            verify(roleRepository, never()).updateClientRole(anyString(), anyString(), any());
+        }
+
+        @Test
+        void doImport_shouldNotUpdateClientRoleWhenImportCarriesNoIdentifiers() {
+            // Given: an existing client role and an imported role without any identifiers (config-as-code case)
+            final RoleRepresentation existingRole = aClientRole(EXISTING_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport = aClientRole(null, null, DESCRIPTION, ATTRIBUTES);
+            when(roleRepository.getClientRoles(REALM_NAME)).thenReturn(Map.of(CLIENT_ID, List.of(existingRole)));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithClientRoles(roleToImport));
+
+            // Then: absent identifiers are not a difference, so no update is sent to Keycloak
+            verify(roleRepository, never()).updateClientRole(anyString(), anyString(), any());
+        }
+
+        @Test
+        void doImport_shouldNotUpdateClientRoleWhenExistingRoleCarriesNoIdentifiers() {
+            // Given: an existing client role without identifiers and an imported role carrying identifiers
+            final RoleRepresentation existingRole = aClientRole(null, null, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport = aClientRole(IMPORTED_ROLE_ID, IMPORTED_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            when(roleRepository.getClientRoles(REALM_NAME)).thenReturn(Map.of(CLIENT_ID, List.of(existingRole)));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithClientRoles(roleToImport));
+
+            // Then: identifiers present only on the import side are not a difference either
+            verify(roleRepository, never()).updateClientRole(anyString(), anyString(), any());
+        }
+
+        @Test
+        void doImport_shouldUpdateClientRoleWhenIdentifiersAndContentDiffer() {
+            // Given: an existing client role and an imported role differing in identifiers AND content
+            final RoleRepresentation existingRole = aClientRole(EXISTING_ROLE_ID, EXISTING_CONTAINER_ID, DESCRIPTION, ATTRIBUTES);
+            final RoleRepresentation roleToImport =
+                    aClientRole(IMPORTED_ROLE_ID, IMPORTED_CONTAINER_ID, CHANGED_DESCRIPTION, CHANGED_ATTRIBUTES);
+            when(roleRepository.getClientRoles(REALM_NAME)).thenReturn(Map.of(CLIENT_ID, List.of(existingRole)));
+
+            // When: the import runs
+            service.doImport(aRealmImportWithClientRoles(roleToImport));
+
+            // Then: the genuine content change is applied to the existing role of the intended client
+            final ArgumentCaptor<RoleRepresentation> captor = ArgumentCaptor.forClass(RoleRepresentation.class);
+            verify(roleRepository).updateClientRole(anyString(), anyString(), captor.capture());
+
+            final RoleRepresentation updatedRole = captor.getValue();
+            assertEquals(CLIENT_ROLE_NAME, updatedRole.getName(), "the existing role must be the update target");
+            assertEquals(EXISTING_ROLE_ID, updatedRole.getId(), "the target instance role id must be preserved");
+            assertEquals(EXISTING_CONTAINER_ID, updatedRole.getContainerId(), "the target instance container id must be preserved");
+            assertEquals(CHANGED_DESCRIPTION, updatedRole.getDescription(), "the new description must be applied");
+            assertEquals(CHANGED_ATTRIBUTES, updatedRole.getAttributes(), "the new attributes must be applied");
+        }
+    }
+
+    private static RealmImport aRealmImportWithRealmRoles(RoleRepresentation... realmRoles) {
+        final RolesRepresentation roles = new RolesRepresentation();
+        roles.setRealm(List.of(realmRoles));
+
+        return aRealmImport(roles);
+    }
+
+    private static RealmImport aRealmImportWithClientRoles(RoleRepresentation... clientRoles) {
+        final RolesRepresentation roles = new RolesRepresentation();
+        roles.setClient(Map.of(CLIENT_ID, List.of(clientRoles)));
+
+        return aRealmImport(roles);
+    }
+
+    private static RealmImport aRealmImport(RolesRepresentation roles) {
+        final RealmImport realmImport = new RealmImport();
+        realmImport.setRealm(REALM_NAME);
+        realmImport.setRoles(roles);
+
+        return realmImport;
+    }
+
+    private static RoleRepresentation aRealmRole(String id, String containerId, String description,
+                                                 Map<String, List<String>> attributes) {
+        return aRole(REALM_ROLE_NAME, false, id, containerId, description, attributes);
+    }
+
+    private static RoleRepresentation aClientRole(String id, String containerId, String description,
+                                                  Map<String, List<String>> attributes) {
+        return aRole(CLIENT_ROLE_NAME, true, id, containerId, description, attributes);
+    }
+
+    private static RoleRepresentation aRole(String name, boolean clientRole, String id, String containerId,
+                                            String description, Map<String, List<String>> attributes) {
+        final RoleRepresentation role = new RoleRepresentation();
+        role.setName(name);
+        role.setId(id);
+        role.setContainerId(containerId);
+        role.setDescription(description);
+        role.setComposite(false);
+        role.setClientRole(clientRole);
+        role.setAttributes(attributes);
+
+        return role;
+    }
+}

--- a/src/test/resources/import-files/roles/80.1_create_realm_with_roles_for_id_mismatch.json
+++ b/src/test/resources/import-files/roles/80.1_create_realm_with_roles_for_id_mismatch.json
@@ -1,0 +1,40 @@
+{
+  "enabled": true,
+  "realm": "realmWithRoles80",
+  "roles": {
+    "realm": [
+      {
+        "name": "my_realm_role_80",
+        "description": "My realm role",
+        "composite": false,
+        "clientRole": false
+      }
+    ],
+    "client": {
+      "moped-client": [
+        {
+          "name": "my_client_role_80",
+          "description": "My moped-client role",
+          "composite": false,
+          "clientRole": true
+        }
+      ]
+    }
+  },
+  "clients": [
+    {
+      "clientId": "moped-client",
+      "name": "moped-client",
+      "description": "Moped-Client",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "my-special-client-secret",
+      "redirectUris": [
+        "*"
+      ],
+      "webOrigins": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/src/test/resources/import-files/roles/80.2_update_realm_with_mismatching_role_ids.json
+++ b/src/test/resources/import-files/roles/80.2_update_realm_with_mismatching_role_ids.json
@@ -1,0 +1,28 @@
+{
+  "enabled": true,
+  "realm": "realmWithRoles80",
+  "roles": {
+    "realm": [
+      {
+        "id": "aaaaaaaa-1111-2222-3333-444444444444",
+        "containerId": "aaaaaaaa-1111-2222-3333-555555555555",
+        "name": "my_realm_role_80",
+        "description": "My realm role",
+        "composite": false,
+        "clientRole": false
+      }
+    ],
+    "client": {
+      "moped-client": [
+        {
+          "id": "bbbbbbbb-1111-2222-3333-444444444444",
+          "containerId": "bbbbbbbb-1111-2222-3333-555555555555",
+          "name": "my_client_role_80",
+          "description": "My moped-client role",
+          "composite": false,
+          "clientRole": true
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/import-files/roles/80.3_update_realm_with_mismatching_role_ids_and_changed_content.json
+++ b/src/test/resources/import-files/roles/80.3_update_realm_with_mismatching_role_ids_and_changed_content.json
@@ -1,0 +1,28 @@
+{
+  "enabled": true,
+  "realm": "realmWithRoles80",
+  "roles": {
+    "realm": [
+      {
+        "id": "aaaaaaaa-1111-2222-3333-444444444444",
+        "containerId": "aaaaaaaa-1111-2222-3333-555555555555",
+        "name": "my_realm_role_80",
+        "description": "My changed realm role",
+        "composite": false,
+        "clientRole": false
+      }
+    ],
+    "client": {
+      "moped-client": [
+        {
+          "id": "bbbbbbbb-1111-2222-3333-444444444444",
+          "containerId": "bbbbbbbb-1111-2222-3333-555555555555",
+          "name": "my_client_role_80",
+          "description": "My changed moped-client role",
+          "composite": false,
+          "clientRole": true
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/import-files/roles/82_import_realm_with_protected_roles.json
+++ b/src/test/resources/import-files/roles/82_import_realm_with_protected_roles.json
@@ -1,0 +1,40 @@
+{
+  "enabled": true,
+  "realm": "realmWithRoles82",
+  "roles": {
+    "realm": [
+      {
+        "id": "cccccccc-1111-2222-3333-444444444444",
+        "containerId": "cccccccc-1111-2222-3333-555555555555",
+        "name": "admin",
+        "composite": false,
+        "clientRole": false
+      },
+      {
+        "id": "cccccccc-1111-2222-3333-666666666666",
+        "containerId": "cccccccc-1111-2222-3333-555555555555",
+        "name": "create-realm",
+        "composite": false,
+        "clientRole": false
+      }
+    ],
+    "client": {
+      "realm-management": [
+        {
+          "id": "dddddddd-1111-2222-3333-444444444444",
+          "containerId": "dddddddd-1111-2222-3333-555555555555",
+          "name": "view-realm",
+          "composite": false,
+          "clientRole": true
+        },
+        {
+          "id": "dddddddd-1111-2222-3333-666666666666",
+          "containerId": "dddddddd-1111-2222-3333-555555555555",
+          "name": "manage-users",
+          "composite": false,
+          "clientRole": true
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Role change-detection compared the server-assigned `id` and `containerId`, so a realm exported from another Keycloak instance made every role look changed and triggered pointless updates. Since Keycloak 26.6.4 those updates fail with HTTP 403 on the `admin`, `create-realm` and `realm-management` roles, aborting the import.

Both identifiers are now excluded from the patch and the equality check for realm and client roles, matching what ClientImportService already does. The existing role's identifiers survive because the patch is built on a clone of it.

Fixes #1672
